### PR TITLE
feat(cli): automation improvements, board linking, and unified UX

### DIFF
--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -36,15 +36,15 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 
 | Column | Option ID |
 |---|---|
-| 💡 Idea | `8fcb0400` |
-| 🔍 Exploration | `41a8303c` |
-| 🧠 Brainstorming | `621c5910` |
-| 📐 Detail Solution | `e1db01e8` |
-| ✅ Approval | `4568409b` |
-| ⚙️ Development | `e8be1b7d` |
-| 🧪 Testing | `8d521907` |
-| 👁 Code Review / PR | `eb6bb6e4` |
-| 🚀 Ready for Production | `d51f149d` |
+| 💡 Idea | `{{ID_IDEA}}` |
+| 🔍 Exploration | `{{ID_EXPLORATION}}` |
+| 🧠 Brainstorming | `{{ID_BRAINSTORMING}}` |
+| 📐 Detail Solution | `{{ID_DETAIL}}` |
+| ✅ Approval | `{{ID_APPROVAL}}` |
+| ⚙️ Development | `{{ID_DEVELOPMENT}}` |
+| 🧪 Testing | `{{ID_TESTING}}` |
+| 👁 Code Review / PR | `{{ID_CODE_REVIEW_PR}}` |
+| 🚀 Ready for Production | `{{ID_READY_FOR_PRODUCTION}}` |
 
 ## Agent × Phase Mapping
 

--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -1,23 +1,28 @@
-# PDLC — agentic-pdlc
+# PDLC — {{PROJECT_NAME}}
 
 ## Board Columns
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
 | 💡 Idea | Backlog — every new issue lands here | Manual |
-| 🔍 Exploration | AI is analyzing code and context | Label `stage:exploration` |
-| 🧠 Brainstorming | AI proposed approaches and trade-offs | Label `stage:brainstorming` |
-| 📐 Detail Solution | AI is writing the technical spec | Label `stage:detailing` |
-| ✅ Approval | Your turn, awaiting `spec:approved` label | Label `spec:approved` |
-| ⚙️ Development | AI implementing the spec | Label `stage:development` |
-| 🧪 Testing | CI pipeline running | GitHub Actions |
-| 👁 Code Review / PR | PR opened, awaiting human review | GitHub Actions |
+| 🔍 Exploration | Claude is analyzing code and context | Label `stage:exploration` |
+| 🧠 Brainstorming | Claude proposed approaches, awaiting PM gate | Label `stage:brainstorming` |
+| 📐 Detail Solution | Claude is writing the technical spec | Label `stage:detailing` |
+| ✅ Approval | Spec ready, awaiting `spec:approved` label | Label `spec:approved` |
+| ⚙️ Development | Agent implementing the spec | Label `stage:development` |
+| 🧪 Testing | CI pipeline or AI QA Agent running (Variant B) | GitHub Actions / QA Agent |
+| 👁 Code Review / PR | PR opened (Variant A) or QA passed (Variant B) | GitHub Actions |
 | 🚀 Ready for Production | Merged | GitHub Actions |
 
 <!--
 Adapt columns as needed. The functional baseline is:
 💡 Idea → ⚙️ Development → 👁 Code Review / PR → 🚀 Ready for Production
 -->
+
+## Workflow Variants (QA Agent)
+
+- **Variant A (Default):** PRs bypass the `Testing` column and land directly in `Code Review / PR`.
+- **Variant B (QA Agent Enabled):** PRs land in the `Testing` column first. An AI QA agent verifies the PR, adding `qa:pass` or `qa:fail`. Only after a `qa:pass` is the issue moved to `Code Review / PR`.
 
 ## Board Identifiers (GitHub Projects)
 
@@ -31,15 +36,15 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 
 | Column | Option ID |
 |---|---|
-| 💡 Idea | `{{ID_IDEA}}` |
-| 🔍 Exploration | `{{ID_EXPLORATION}}` |
-| 🧠 Brainstorming | `{{ID_BRAINSTORMING}}` |
-| 📐 Detail Solution | `{{ID_DETAIL}}` |
-| ✅ Approval | `{{ID_APPROVAL}}` |
-| ⚙️ Development | `{{ID_DEVELOPMENT}}` |
-| 🧪 Testing | `{{ID_TESTING}}` |
-| 👁 Code Review / PR | `{{ID_CODE_REVIEW_PR}}` |
-| 🚀 Ready for Production | `{{ID_READY_FOR_PRODUCTION}}` |
+| 💡 Idea | `8fcb0400` |
+| 🔍 Exploration | `41a8303c` |
+| 🧠 Brainstorming | `621c5910` |
+| 📐 Detail Solution | `e1db01e8` |
+| ✅ Approval | `4568409b` |
+| ⚙️ Development | `e8be1b7d` |
+| 🧪 Testing | `8d521907` |
+| 👁 Code Review / PR | `eb6bb6e4` |
+| 🚀 Ready for Production | `d51f149d` |
 
 ## Agent × Phase Mapping
 
@@ -94,7 +99,7 @@ This triggers the implementation agent via `agent-trigger.yml`.
 
 An issue is truly done when:
 - [ ] All Acceptance Criteria described in the body are implemented
-- [ ] Tests passing: `echo "No tests/build needed."`
+- [ ] Tests passing: `{{TEST_COMMAND}}`
 - [ ] No invariant violations (CI green)
 - [ ] Associated PR explicitly contains `Closes #N`
 - [ ] Basic manual smoke test executed after deploy (when applicable)

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -19,8 +19,9 @@ Specifically, check for:
 - `.github/workflows/pdlc-health-check.yml`
 
 If any of these files are missing, you are in **Setup Mode**. Do not proceed with feature requests until setup is complete.
-1. Acknowledge that the framework is not yet set up.
-2. Interactively ask the user for required values **one group at a time**:
+1. **Language Detection:** Analyze the user's previous prompts and preferred language. Conduct this entire Setup Mode and ask all your interactive questions in that same language.
+2. Acknowledge that the framework is not yet set up.
+3. Interactively ask the user for required values **one group at a time**:
    - **Project basics:** Project Name, Description, Technical Stack (Structure), and GitHub Username (for CODEOWNERS security).
    - **Commands:** Test command, Lint command, Build command.
    - **Invariants:** Critical business rules agents must never violate (e.g. Human-in-the-loop).

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 // The directory where CLI is executed
 const targetDir = process.cwd();
@@ -152,7 +152,7 @@ async function runSetup() {
   console.log(`\n${cyan}${i18n.creating_labels}${reset}`);
   for (const label of labels) {
     try {
-      execSync(`gh label create "${label.name}" --color "${label.color}" --description "${label.description}" --repo ${repo} --force`, { stdio: 'ignore' });
+      execFileSync('gh', ['label', 'create', label.name, '--color', label.color, '--description', label.description, '--repo', repo, '--force'], { stdio: 'ignore' });
       console.log(`  ${i18n.label_ok}${label.name}`);
     } catch (err) {
       console.log(`  ${i18n.label_warn}${label.name}`);
@@ -162,7 +162,7 @@ async function runSetup() {
   // Branch Protection
   console.log(`\n${cyan}${i18n.applying_protection}'${branchName}'...${reset}`);
   const protectionPayload = {
-    required_status_checks: { strict: true, checks: [{ context: "Sentinel / CI" }] },
+    required_status_checks: { strict: true, checks: [{ context: "Detect Project Board Drift" }] },
     enforce_admins: false,
     required_pull_request_reviews: { required_approving_review_count: 1, dismiss_stale_reviews: true },
     restrictions: null,
@@ -171,7 +171,7 @@ async function runSetup() {
   };
 
   try {
-    execSync(`gh api repos/${repo}/branches/${branchName}/protection --method PUT --input -`, {
+    execFileSync('gh', ['api', `repos/${repo}/branches/${branchName}/protection`, '--method', 'PUT', '--input', '-'], {
       input: JSON.stringify(protectionPayload),
       stdio: 'ignore'
     });
@@ -185,14 +185,14 @@ async function runSetup() {
   let ownerId, projectId;
   try {
     if (isOrg) {
-      const orgOutput = execSync(`gh api graphql -f query='query($login: String!) { organization(login: $login) { id } }' -f login="${repoOwner}" --jq '.data.organization.id'`).toString().trim();
+      const orgOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=query($login: String!) { organization(login: $login) { id } }', '-f', `login=${repoOwner}`, '--jq', '.data.organization.id']).toString().trim();
       ownerId = orgOutput;
     } else {
-      const userOutput = execSync(`gh api graphql -f query='{ viewer { id } }' --jq '.data.viewer.id'`).toString().trim();
+      const userOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query={ viewer { id } }', '--jq', '.data.viewer.id']).toString().trim();
       ownerId = userOutput;
     }
 
-    const projectCreateOutput = execSync(`gh api graphql -f query='mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id } } }' -f owner="${ownerId}" -f title="PDLC - ${repoName}" --jq '.data.createProjectV2.projectV2.id'`).toString().trim();
+    const projectCreateOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id } } }', '-f', `owner=${ownerId}`, '-f', `title=PDLC - ${repoName}`, '--jq', '.data.createProjectV2.projectV2.id']).toString().trim();
     projectId = projectCreateOutput;
 
     console.log(`  ${i18n.project_ok}${projectId})`);
@@ -206,7 +206,7 @@ async function runSetup() {
   if (projectId) {
     console.log(`  ${cyan}${i18n.config_columns}${reset}`);
     try {
-      const fieldsOutput = execSync(`gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name } } } } } }' -f projectId="${projectId}" --jq '.data.node.fields.nodes[] | select(.name == "Status") | .id'`).toString().trim();
+      const fieldsOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name } } } } } }', '-f', `projectId=${projectId}`, '--jq', '.data.node.fields.nodes[] | select(.name == "Status") | .id']).toString().trim();
       statusFieldId = fieldsOutput;
 
       if (statusFieldId) {
@@ -243,9 +243,9 @@ async function runSetup() {
           }
         });
 
-        const updateOutput = execSync(`gh api graphql --input -`, { input: queryPayload }).toString().trim();
-        const jsonResponse = JSON.parse(updateOutput);
-        const returnedOptions = jsonResponse.data.updateProjectV2SingleSelectField.projectV2SingleSelectField.options;
+        const updateOutput = execFileSync('gh', ['api', 'graphql', '--input', '-'], { input: queryPayload }).toString().trim();
+        const jsonResponse = updateOutput ? JSON.parse(updateOutput) : null;
+        const returnedOptions = jsonResponse?.data?.updateProjectV2SingleSelectField?.projectV2SingleSelectField?.options || [];
         
         for (const opt of returnedOptions) {
           optionMap[opt.name] = opt.id;
@@ -311,7 +311,7 @@ async function runSetup() {
       console.log(`${cyan}${i18n.step_1}${reset}`);
       console.log(`${cyan}${i18n.step_2}${reset}`);
       console.log(`${cyan}>>> English: "Read .agentic-setup.md and guide me through the setup."${reset}`);
-      console.log(`${cyan}>>> Español: "Lea el arquivo .agentic-setup.md e inicie el Setup Mode"${reset}`);
+      console.log(`${cyan}>>> Español: "Lea el archivo .agentic-setup.md e inicie el Setup Mode"${reset}`);
       console.log(`${cyan}>>> Português: "Leia o arquivo .agentic-setup.md e inicie o Setup Mode."${reset}\n`);
       console.log(`${i18n.note_cleanup}`);
     } else {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,8 +69,8 @@ const i18n = {
   cursor_done: t('🎉 Done! To start the conversational setup:', '🎉 Pronto! Para iniciar o setup conversacional:', '🎉 ¡Listo! Para iniciar la configuración conversacional:'),
   cursor_step_1: t('\t1. Open Cursor', '\t1. Abra o Cursor', '\t1. Abre Cursor'),
   cursor_step_2: t('\t2. Open Composer (Cmd+I or Cmd+L) and type: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n', '\t2. Abra o Composer (Cmd+I ou Cmd+L) e digite: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n', '\t2. Abre Composer (Cmd+I o Cmd+L) y escribe: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n'),
-  generic_written: t('✅ Agent generic setup instructions written to .agentic-setup-prompt.md', '✅ Instruções genéricas salvas em .agentic-setup-prompt.md', '✅ Instrucciones genéricas guardadas en .agentic-setup-prompt.md'),
-  generic_done: t('Provide the .agentic-setup-prompt.md file to your AI agent and ask it to execute Setup Mode!\n', 'Forneça o arquivo .agentic-setup-prompt.md para o seu agente e peça para executar o Setup Mode!\n', '¡Proporciona el archivo .agentic-setup-prompt.md a tu agente de IA y pídele que ejecute el Setup Mode!\n')
+  generic_written: t('✅ Agent generic setup instructions written to .agentic-setup.md', '✅ Instruções genéricas salvas em .agentic-setup.md', '✅ Instrucciones genéricas guardadas en .agentic-setup.md'),
+  generic_done: t('Tell your AI agent to read and execute the .agentic-setup.md file!\n', 'Diga ao seu agente para ler e executar o arquivo .agentic-setup.md!\n', '¡Dile a tu agente de IA que lea y ejecute el archivo .agentic-setup.md!\n')
 };
 
 const cyan = '\x1b[36m';
@@ -112,24 +112,45 @@ async function runSetup() {
 
   const agentAnswer = await askQuestion(i18n.ask_agent);
   const agent = agentAnswer.trim().toLowerCase();
-
-  const repoUrlAnswer = await askQuestion(i18n.ask_repo);
-  let repoUrl = repoUrlAnswer.trim();
-  if (repoUrl.endsWith('/')) repoUrl = repoUrl.slice(0, -1);
-  const repoParts = repoUrl.split('/');
-  if (repoParts.length < 2) {
-    console.error(`${red}${i18n.invalid_repo}${reset}`);
-    process.exit(1);
+  if (!['claude', 'cursor', 'copilot'].includes(agent)) {
+    console.log(t(`⚠️ Agent '${agent}' not recognized natively. Will use generic setup.`, `⚠️ Agente '${agent}' não reconhecido nativamente. Usará setup genérico.`, `⚠️ Agente '${agent}' no reconocido nativamente. Usará configuración genérica.`));
   }
-  const repoOwner = repoParts[repoParts.length - 2];
-  const repoName = repoParts[repoParts.length - 1];
-  const repo = `${repoOwner}/${repoName}`;
 
-  const accountTypeAnswer = await askQuestion(i18n.ask_org);
-  const isOrg = accountTypeAnswer.trim().toLowerCase() === 'org' || accountTypeAnswer.trim().toLowerCase() === 'organization';
+  let repoOwner, repoName, repo;
+  while (true) {
+    let repoUrl = (await askQuestion(i18n.ask_repo)).trim();
+    if (repoUrl.endsWith('/')) repoUrl = repoUrl.slice(0, -1);
+    const repoParts = repoUrl.split('/');
+    if (repoParts.length >= 2) {
+      repoOwner = repoParts[repoParts.length - 2];
+      repoName = repoParts[repoParts.length - 1];
+      repo = `${repoOwner}/${repoName}`;
+      break;
+    }
+    console.log(`${red}${i18n.invalid_repo}${reset}`);
+  }
 
-  const branchAnswer = await askQuestion(i18n.ask_branch);
-  const branchName = branchAnswer.trim() || 'main';
+  const askProjectName = t(`What is the project name for the board? (default: ${repoName.toUpperCase()}): `, `Qual o nome do projeto em que o board será configurado? (padrão: ${repoName.toUpperCase()}): `, `¿Cuál es el nombre del proyecto en el que se configurará el board? (por defecto: ${repoName.toUpperCase()}): `);
+  const projectNameAnswer = await askQuestion(askProjectName);
+  const projectName = projectNameAnswer.trim() ? projectNameAnswer.trim().toUpperCase() : repoName.toUpperCase();
+  const boardName = `BOARD - ${projectName}`;
+
+  let isOrg = false;
+  try {
+    const ownerType = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.owner.type']).toString().trim();
+    isOrg = ownerType === 'Organization';
+  } catch (err) {
+    const accountTypeAnswer = await askQuestion(i18n.ask_org);
+    isOrg = accountTypeAnswer.trim().toLowerCase() === 'org' || accountTypeAnswer.trim().toLowerCase() === 'organization';
+  }
+
+  let branchName = 'main';
+  try {
+    branchName = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.default_branch']).toString().trim() || 'main';
+  } catch (err) {
+    const branchAnswer = await askQuestion(i18n.ask_branch);
+    if (branchAnswer.trim()) branchName = branchAnswer.trim();
+  }
 
   console.log(`\n${yellow}${i18n.starting_setup}${reset}`);
 
@@ -178,6 +199,12 @@ async function runSetup() {
     console.log(`  ${i18n.protection_ok}${branchName}`);
   } catch (err) {
     console.log(`  ${i18n.protection_warn}`);
+    try {
+      const visibility = execFileSync('gh', ['repo', 'view', repo, '--json', 'visibility', '--jq', '.visibility']).toString().trim();
+      if (visibility.toUpperCase() === 'PRIVATE') {
+        console.log(`  ${yellow}Note: Branch protection on Private repos requires GitHub Pro or GitHub Team.${reset}`);
+      }
+    } catch (e) {}
   }
 
   // Project V2
@@ -192,7 +219,7 @@ async function runSetup() {
       ownerId = userOutput;
     }
 
-    const projectCreateOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id } } }', '-f', `owner=${ownerId}`, '-f', `title=PDLC - ${repoName}`, '--jq', '.data.createProjectV2.projectV2.id']).toString().trim();
+    const projectCreateOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id } } }', '-f', `owner=${ownerId}`, '-f', `title=${boardName}`, '--jq', '.data.createProjectV2.projectV2.id']).toString().trim();
     projectId = projectCreateOutput;
 
     console.log(`  ${i18n.project_ok}${projectId})`);
@@ -223,13 +250,15 @@ async function runSetup() {
         ];
 
         const updateFieldQuery = `mutation($projectId: ID!, $fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
-          updateProjectV2SingleSelectField(input: {
+          updateProjectV2Field(input: {
             projectId: $projectId,
             fieldId: $fieldId,
-            options: $options
+            singleSelectOptions: $options
           }) { 
-            projectV2SingleSelectField { 
-              options { id name } 
+            projectV2Field { 
+              ... on ProjectV2SingleSelectField {
+                options { id name } 
+              }
             } 
           }
         }`;
@@ -245,7 +274,7 @@ async function runSetup() {
 
         const updateOutput = execFileSync('gh', ['api', 'graphql', '--input', '-'], { input: queryPayload }).toString().trim();
         const jsonResponse = updateOutput ? JSON.parse(updateOutput) : null;
-        const returnedOptions = jsonResponse?.data?.updateProjectV2SingleSelectField?.projectV2SingleSelectField?.options || [];
+        const returnedOptions = jsonResponse?.data?.updateProjectV2Field?.projectV2Field?.options || [];
         
         for (const opt of returnedOptions) {
           optionMap[opt.name] = opt.id;
@@ -337,11 +366,11 @@ async function runSetup() {
     }
   } else {
     // Generic fallback mapping
-    const dest = path.join(targetDir, '.agentic-setup-prompt.md');
+    const dest = path.join(targetDir, '.agentic-setup.md');
     fs.copyFileSync(claudeSetupSrc, dest);
     console.log(`${i18n.generic_written}`);
     console.log(`\n${green}${i18n.cursor_done}${reset}`);
-    console.log(`${cyan}${i18n.generic_done}${reset}`);
+    console.log(`${cyan}>>> ${i18n.generic_done}${reset}`);
   }
 
   rl.close();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
+const { execSync } = require('child_process');
 
 // The directory where CLI is executed
 const targetDir = process.cwd();
@@ -14,13 +15,72 @@ const rl = readline.createInterface({
   output: process.stdout
 });
 
+function askQuestion(query) {
+  return new Promise(resolve => rl.question(query, resolve));
+}
+
+// Detect language
+const locale = Intl.DateTimeFormat().resolvedOptions().locale || 'en-US';
+const isPt = locale.toLowerCase().startsWith('pt');
+const isEs = locale.toLowerCase().startsWith('es');
+
+function t(en, pt, es) {
+  if (isPt) return pt;
+  if (isEs) return es || en; // Fallback para inglês se faltar espanhol
+  return en;
+}
+
+const i18n = {
+  welcome: t('🤖 Welcome to Agentic PDLC Boilerplate Bootstrap! 🤖', '🤖 Bem-vindo ao Agentic PDLC Boilerplate Bootstrap! 🤖', '🤖 ¡Bienvenido a Agentic PDLC Boilerplate Bootstrap! 🤖'),
+  checking_gh: t('Checking GitHub CLI (gh) installation...', 'Verificando instalação do GitHub CLI (gh)...', 'Verificando la instalación de GitHub CLI (gh)...'),
+  gh_ok: t('✅ GitHub CLI is authenticated.', '✅ GitHub CLI está autenticado.', '✅ GitHub CLI está autenticado.'),
+  gh_error: t('❌ GitHub CLI (gh) is not installed or not authenticated.', '❌ GitHub CLI (gh) não está instalado ou não autenticado.', '❌ GitHub CLI (gh) no está instalado o no está autenticado.'),
+  gh_install: t('Please install it from https://cli.github.com/ and run "gh auth login" before continuing.\n', 'Por favor, instale em https://cli.github.com/ e rode "gh auth login" antes de continuar.\n', 'Por favor, instálalo desde https://cli.github.com/ y ejecuta "gh auth login" antes de continuar.\n'),
+  ask_agent: t('Which AI Agent will you use for the setup? (e.g. claude, cursor, copilot, or other): ', 'Qual Agente de IA você usará para o setup? (ex: claude, cursor, copilot, ou outro): ', '¿Qué Agente de IA usarás para la configuración? (ej: claude, cursor, copilot, u otro): '),
+  ask_repo: t('What is your GitHub repository URL? (e.g., https://github.com/YOUR_USER/repo_name): ', 'Qual é a URL do seu repositório no GitHub? (ex: https://github.com/SEU_USUARIO/repo_name): ', '¿Cuál es la URL de tu repositorio en GitHub? (ej: https://github.com/TU_USUARIO/repo_name): '),
+  invalid_repo: t('❌ Invalid repository URL. Expected format: https://github.com/OWNER/REPO', '❌ URL de repositório inválida. Formato esperado: https://github.com/OWNER/REPO', '❌ URL de repositorio inválida. Formato esperado: https://github.com/OWNER/REPO'),
+  ask_org: t('Does this repository belong to a personal User account (e.g., github.com/rafaeltcosta86) or an Organization (e.g., github.com/google-labs)? (user/org): ', 'Esse repositório pertence a um Usuário pessoal (ex: github.com/rafaeltcosta86) ou a uma Organização (ex: github.com/google-labs)? (user/org): ', '¿Este repositorio pertenece a un Usuario personal (ej: github.com/rafaeltcosta86) o a una Organización (ej: github.com/google-labs)? (user/org): '),
+  ask_branch: t('What is your main branch name? (default: main): ', 'Qual o nome da sua branch principal? (padrão: main): ', '¿Cuál es el nombre de tu rama principal? (por defecto: main): '),
+  starting_setup: t('Starting automated repository setup...', 'Iniciando o setup automatizado do repositório...', 'Iniciando la configuración automatizada del repositorio...'),
+  creating_labels: t('[1/3] Creating repository labels...', '[1/3] Criando labels no repositório...', '[1/3] Creando etiquetas (labels) en el repositorio...'),
+  label_ok: t('✅ Label created: ', '✅ Label criada: ', '✅ Etiqueta creada: '),
+  label_warn: t('⚠️ Failed to create label (might already exist): ', '⚠️ Falha ao criar label (talvez já exista): ', '⚠️ Fallo al crear etiqueta (quizás ya exista): '),
+  applying_protection: t('[2/3] Applying branch protection on ', '[2/3] Aplicando proteção de branch em ', '[2/3] Aplicando protección de rama en '),
+  protection_ok: t('✅ Branch protection applied to ', '✅ Proteção de branch aplicada em ', '✅ Protección de rama aplicada a '),
+  protection_warn: t('⚠️ Failed to apply branch protection. (Do you have GitHub Pro or is the repo Public?)', '⚠️ Falha ao aplicar proteção de branch. (Você tem GitHub Pro ou o repo é Público?)', '⚠️ Fallo al aplicar protección de rama. (¿Tienes GitHub Pro o el repositorio es Público?)'),
+  creating_project: t('[3/3] Creating Project V2 Board...', '[3/3] Criando Project V2 Board...', '[3/3] Creando Project V2 Board...'),
+  project_ok: t('✅ Project created (ID: ', '✅ Projeto criado (ID: ', '✅ Proyecto creado (ID: '),
+  project_err: t('❌ Failed to create project. Error: ', '❌ Falha ao criar o projeto. Erro: ', '❌ Fallo al crear el proyecto. Error: '),
+  config_columns: t('Configuring Project Columns...', 'Configurando colunas do Projeto...', 'Configurando columnas del Proyecto...'),
+  columns_ok: t('✅ Project columns configured successfully.', '✅ Colunas do projeto configuradas com sucesso.', '✅ Columnas del proyecto configuradas con éxito.'),
+  columns_warn: t('⚠️ Failed to configure project columns. You may need to add them manually.', '⚠️ Falha ao configurar colunas. Você pode precisar adicioná-las manualmente.', '⚠️ Fallo al configurar columnas. Es posible que debas agregarlas manualmente.'),
+  scaffolding: t('Scaffolding Agentic PDLC into your project...', 'Injetando Agentic PDLC no seu projeto...', 'Inyectando Agentic PDLC en tu proyecto...'),
+  templates_copied: t('✅ Templates copied to .agentic-pdlc/templates/', '✅ Templates copiados para .agentic-pdlc/templates/', '✅ Plantillas copiadas a .agentic-pdlc/templates/'),
+  pdlc_prefilled: t('✅ Pre-filled pdlc.md with Project ID, Status Field ID, and Column Option IDs.', '✅ pdlc.md preenchido com Project ID, Status Field ID, e Column Option IDs.', '✅ pdlc.md completado con Project ID, Status Field ID y Column Option IDs.'),
+  setup_written: t('✅ Setup agent profile written to .agentic-setup.md\n', '✅ Perfil de setup do agente salvo em .agentic-setup.md\n', '✅ Perfil de configuración del agente guardado en .agentic-setup.md\n'),
+  framework_scaffolded: t('🎉 Framework files scaffolded to .agentic-pdlc/templates/', '🎉 Arquivos do framework injetados em .agentic-pdlc/templates/', '🎉 Archivos del framework inyectados en .agentic-pdlc/templates/'),
+  next_steps: t('👉 NEXT STEPS:', '👉 PRÓXIMOS PASSOS:', '👉 PRÓXIMOS PASOS:'),
+  step_1: t('1. Open your AI Assistant (Claude, Cursor, Copilot, etc).', '1. Abra o seu Assistente de IA (Claude, Cursor, Copilot, etc).', '1. Abre tu Asistente de IA (Claude, Cursor, Copilot, etc).'),
+  step_2: t('2. Ask it to read the .agentic-setup.md and start Setup Mode in any language you prefer. Example 👇', '2. Peça para ele ler o .agentic-setup.md e iniciar o Setup Mode. Exemplo 👇', '2. Pídele que lea .agentic-setup.md e inicie el Setup Mode. Ejemplo 👇'),
+  note_cleanup: t('Note: The agent will clean up the .agentic-setup.md file automatically when finished.\n', 'Nota: O agente irá limpar o arquivo .agentic-setup.md automaticamente quando terminar.\n', 'Nota: El agente limpiará el archivo .agentic-setup.md automáticamente cuando termine.\n'),
+  missing_claude: t('❌ Could not find claude instruction file at ', '❌ Não foi possível encontrar o arquivo de instrução em ', '❌ No se pudo encontrar el archivo de instrucción en '),
+  cursor_rules_written: t('✅ Default cursor rules written to .cursorrules', '✅ Regras padrão do cursor salvas em .cursorrules', '✅ Reglas por defecto de cursor guardadas en .cursorrules'),
+  cursor_setup_written: t('✅ Framework Setup Instructions written to .agentic-pdlc/SETUP_PROMPT.md', '✅ Instruções de Setup do Framework salvas em .agentic-pdlc/SETUP_PROMPT.md', '✅ Instrucciones de Setup del Framework guardadas en .agentic-pdlc/SETUP_PROMPT.md'),
+  cursor_done: t('🎉 Done! To start the conversational setup:', '🎉 Pronto! Para iniciar o setup conversacional:', '🎉 ¡Listo! Para iniciar la configuración conversacional:'),
+  cursor_step_1: t('\t1. Open Cursor', '\t1. Abra o Cursor', '\t1. Abre Cursor'),
+  cursor_step_2: t('\t2. Open Composer (Cmd+I or Cmd+L) and type: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n', '\t2. Abra o Composer (Cmd+I ou Cmd+L) e digite: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n', '\t2. Abre Composer (Cmd+I o Cmd+L) y escribe: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n'),
+  generic_written: t('✅ Agent generic setup instructions written to .agentic-setup-prompt.md', '✅ Instruções genéricas salvas em .agentic-setup-prompt.md', '✅ Instrucciones genéricas guardadas en .agentic-setup-prompt.md'),
+  generic_done: t('Provide the .agentic-setup-prompt.md file to your AI agent and ask it to execute Setup Mode!\n', 'Forneça o arquivo .agentic-setup-prompt.md para o seu agente e peça para executar o Setup Mode!\n', '¡Proporciona el archivo .agentic-setup-prompt.md a tu agente de IA y pídele que ejecute el Setup Mode!\n')
+};
+
 const cyan = '\x1b[36m';
 const reset = '\x1b[0m';
 const green = '\x1b[32m';
 const yellow = '\x1b[33m';
+const red = '\x1b[31m';
 
 console.log(`${cyan}================================================================${reset}`);
-console.log(`${cyan}🤖 Welcome to Agentic PDLC Boilerplate Bootstrap! 🤖${reset}`);
+console.log(`${cyan}${i18n.welcome}${reset}`);
 console.log(`${cyan}================================================================${reset}\n`);
 
 // Helper function to recursively copy directories
@@ -39,10 +99,166 @@ function copyDirSync(src, dest) {
   }
 }
 
-rl.question('Which AI Agent will you use for the setup? (e.g. claude, cursor, copilot, or other): ', (answer) => {
-  const agent = answer.trim().toLowerCase();
-  
-  console.log(`\n${yellow}Scaffolding Agentic PDLC into your project...${reset}`);
+async function runSetup() {
+  console.log(`${yellow}${i18n.checking_gh}${reset}`);
+  try {
+    execSync('gh auth status', { stdio: 'ignore' });
+    console.log(`${green}${i18n.gh_ok}${reset}\n`);
+  } catch (error) {
+    console.error(`${red}${i18n.gh_error}${reset}`);
+    console.error(`${i18n.gh_install}`);
+    process.exit(1);
+  }
+
+  const agentAnswer = await askQuestion(i18n.ask_agent);
+  const agent = agentAnswer.trim().toLowerCase();
+
+  const repoUrlAnswer = await askQuestion(i18n.ask_repo);
+  let repoUrl = repoUrlAnswer.trim();
+  if (repoUrl.endsWith('/')) repoUrl = repoUrl.slice(0, -1);
+  const repoParts = repoUrl.split('/');
+  if (repoParts.length < 2) {
+    console.error(`${red}${i18n.invalid_repo}${reset}`);
+    process.exit(1);
+  }
+  const repoOwner = repoParts[repoParts.length - 2];
+  const repoName = repoParts[repoParts.length - 1];
+  const repo = `${repoOwner}/${repoName}`;
+
+  const accountTypeAnswer = await askQuestion(i18n.ask_org);
+  const isOrg = accountTypeAnswer.trim().toLowerCase() === 'org' || accountTypeAnswer.trim().toLowerCase() === 'organization';
+
+  const branchAnswer = await askQuestion(i18n.ask_branch);
+  const branchName = branchAnswer.trim() || 'main';
+
+  console.log(`\n${yellow}${i18n.starting_setup}${reset}`);
+
+  // Labels
+  const labels = [
+    { name: 'stage:exploration', color: '9b59b6', description: 'Issue is being evaluated' },
+    { name: 'stage:brainstorming', color: 'e84393', description: 'Proposed approaches awaiting PM gate' },
+    { name: 'stage:detailing', color: '3498db', description: 'Technical spec is being written' },
+    { name: 'stage:development', color: 'e67e22', description: 'Agent is implementing the spec' },
+    { name: 'stage:testing', color: '8e44ad', description: 'Agent is testing the implementation' },
+    { name: 'spec:approved', color: '0e8a16', description: 'Spec approved — agent can implement' },
+    { name: 'pr:in-review', color: 'e4e669', description: 'PR awaiting code review' },
+    { name: 'pr:approved', color: '0e8a16', description: 'PR approved, ready for merge' },
+    { name: 'architecture-violation', color: 'd93f0b', description: 'Invariant violation detected by CI' },
+    { name: 'qa:approved', color: '0e8a16', description: 'QA Agent approved the implementation' },
+    { name: 'qa:needs-work', color: 'd93f0b', description: 'QA Agent found issues' },
+    { name: 'jules', color: '5319e7', description: 'Jules AI Agent' }
+  ];
+
+  console.log(`\n${cyan}${i18n.creating_labels}${reset}`);
+  for (const label of labels) {
+    try {
+      execSync(`gh label create "${label.name}" --color "${label.color}" --description "${label.description}" --repo ${repo} --force`, { stdio: 'ignore' });
+      console.log(`  ${i18n.label_ok}${label.name}`);
+    } catch (err) {
+      console.log(`  ${i18n.label_warn}${label.name}`);
+    }
+  }
+
+  // Branch Protection
+  console.log(`\n${cyan}${i18n.applying_protection}'${branchName}'...${reset}`);
+  const protectionPayload = {
+    required_status_checks: { strict: true, checks: [{ context: "Sentinel / CI" }] },
+    enforce_admins: false,
+    required_pull_request_reviews: { required_approving_review_count: 1, dismiss_stale_reviews: true },
+    restrictions: null,
+    allow_force_pushes: false,
+    allow_deletions: false
+  };
+
+  try {
+    execSync(`gh api repos/${repo}/branches/${branchName}/protection --method PUT --input -`, {
+      input: JSON.stringify(protectionPayload),
+      stdio: 'ignore'
+    });
+    console.log(`  ${i18n.protection_ok}${branchName}`);
+  } catch (err) {
+    console.log(`  ${i18n.protection_warn}`);
+  }
+
+  // Project V2
+  console.log(`\n${cyan}${i18n.creating_project}${reset}`);
+  let ownerId, projectId;
+  try {
+    if (isOrg) {
+      const orgOutput = execSync(`gh api graphql -f query='query($login: String!) { organization(login: $login) { id } }' -f login="${repoOwner}" --jq '.data.organization.id'`).toString().trim();
+      ownerId = orgOutput;
+    } else {
+      const userOutput = execSync(`gh api graphql -f query='{ viewer { id } }' --jq '.data.viewer.id'`).toString().trim();
+      ownerId = userOutput;
+    }
+
+    const projectCreateOutput = execSync(`gh api graphql -f query='mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id } } }' -f owner="${ownerId}" -f title="PDLC - ${repoName}" --jq '.data.createProjectV2.projectV2.id'`).toString().trim();
+    projectId = projectCreateOutput;
+
+    console.log(`  ${i18n.project_ok}${projectId})`);
+  } catch (err) {
+    console.log(`  ${i18n.project_err}${err.message}`);
+  }
+
+  let statusFieldId;
+  let optionMap = {};
+
+  if (projectId) {
+    console.log(`  ${cyan}${i18n.config_columns}${reset}`);
+    try {
+      const fieldsOutput = execSync(`gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name } } } } } }' -f projectId="${projectId}" --jq '.data.node.fields.nodes[] | select(.name == "Status") | .id'`).toString().trim();
+      statusFieldId = fieldsOutput;
+
+      if (statusFieldId) {
+        const columns = [
+          { name: "💡 Idea", description: "Backlog", color: "GRAY" },
+          { name: "🔍 Exploration", description: "Claude is analyzing", color: "PURPLE" },
+          { name: "🧠 Brainstorming", description: "Awaiting PM gate", color: "PINK" },
+          { name: "📐 Detail Solution", description: "Technical spec", color: "BLUE" },
+          { name: "✅ Approval", description: "Spec ready", color: "GREEN" },
+          { name: "⚙️ Development", description: "Agent implementing", color: "ORANGE" },
+          { name: "🧪 Testing", description: "QA testing", color: "RED" },
+          { name: "👁 Code Review / PR", description: "PR opened", color: "YELLOW" },
+          { name: "🚀 Production", description: "Merged", color: "GREEN" }
+        ];
+
+        const updateFieldQuery = `mutation($projectId: ID!, $fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+          updateProjectV2SingleSelectField(input: {
+            projectId: $projectId,
+            fieldId: $fieldId,
+            options: $options
+          }) { 
+            projectV2SingleSelectField { 
+              options { id name } 
+            } 
+          }
+        }`;
+
+        const queryPayload = JSON.stringify({
+          query: updateFieldQuery,
+          variables: {
+            projectId: projectId,
+            fieldId: statusFieldId,
+            options: columns
+          }
+        });
+
+        const updateOutput = execSync(`gh api graphql --input -`, { input: queryPayload }).toString().trim();
+        const jsonResponse = JSON.parse(updateOutput);
+        const returnedOptions = jsonResponse.data.updateProjectV2SingleSelectField.projectV2SingleSelectField.options;
+        
+        for (const opt of returnedOptions) {
+          optionMap[opt.name] = opt.id;
+        }
+
+        console.log(`  ${i18n.columns_ok}`);
+      }
+    } catch (err) {
+      console.log(`  ${i18n.columns_warn}`);
+    }
+  }
+
+  console.log(`\n${yellow}${i18n.scaffolding}${reset}`);
 
   // We copy the templates folder so the agent has the real text logic to replace and rename
   const sourceTemplates = path.join(sourceDir, 'templates');
@@ -50,7 +266,33 @@ rl.question('Which AI Agent will you use for the setup? (e.g. claude, cursor, co
   
   if (fs.existsSync(sourceTemplates)) {
     copyDirSync(sourceTemplates, targetTemplates);
-    console.log(`✅ Templates copied to .agentic-pdlc/templates/`);
+    console.log(`${i18n.templates_copied}`);
+
+    // Substitute values in docs/pdlc.md automatically
+    const pdlcDest = path.join(targetTemplates, 'docs', 'pdlc.md');
+    if (fs.existsSync(pdlcDest)) {
+      let pdlcContent = fs.readFileSync(pdlcDest, 'utf8');
+      
+      if (projectId) pdlcContent = pdlcContent.replace(/\{\{PROJECT_ID\}\}/g, projectId);
+      if (statusFieldId) pdlcContent = pdlcContent.replace(/\{\{STATUS_FIELD_ID\}\}/g, statusFieldId);
+      pdlcContent = pdlcContent.replace(/\{\{REPO_OWNER\}\}/g, repoOwner);
+      pdlcContent = pdlcContent.replace(/\{\{REPO_NAME\}\}/g, repoName);
+
+      if (Object.keys(optionMap).length > 0) {
+        pdlcContent = pdlcContent.replace(/\{\{ID_IDEA\}\}/g, optionMap["💡 Idea"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_EXPLORATION\}\}/g, optionMap["🔍 Exploration"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_BRAINSTORMING\}\}/g, optionMap["🧠 Brainstorming"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_DETAIL\}\}/g, optionMap["📐 Detail Solution"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_APPROVAL\}\}/g, optionMap["✅ Approval"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_DEVELOPMENT\}\}/g, optionMap["⚙️ Development"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_TESTING\}\}/g, optionMap["🧪 Testing"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_CODE_REVIEW_PR\}\}/g, optionMap["👁 Code Review / PR"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_PRODUCTION\}\}/g, optionMap["🚀 Production"] || 'MISSING_ID');
+      }
+
+      fs.writeFileSync(pdlcDest, pdlcContent);
+      console.log(`${i18n.pdlc_prefilled}`);
+    }
   }
 
   // Handle the specific setup instructions target
@@ -61,19 +303,19 @@ rl.question('Which AI Agent will you use for the setup? (e.g. claude, cursor, co
     if (fs.existsSync(claudeSetupSrc)) {
       const dest = path.join(targetDir, '.agentic-setup.md');
       fs.copyFileSync(claudeSetupSrc, dest);
-      console.log(`✅ Setup agent profile written to .agentic-setup.md\n`);
+      console.log(`${i18n.setup_written}`);
       console.log(`${green}============================================================${reset}`);
-      console.log(`${green}🎉 Framework files scaffolded to .agentic-pdlc/templates/${reset}`);
+      console.log(`${green}${i18n.framework_scaffolded}${reset}`);
       console.log(`${green}============================================================${reset}\n`);
-      console.log(`${yellow}👉 NEXT STEPS:${reset}`);
-      console.log(`${cyan}1. Open your AI Assistant (Claude, Cursor, Copilot, etc).${reset}`);
-      console.log(`${cyan}2. Ask it to read the .agentic-setup.md and start Setup Mode in any language you prefer. Example 👇${reset}`);
+      console.log(`${yellow}${i18n.next_steps}${reset}`);
+      console.log(`${cyan}${i18n.step_1}${reset}`);
+      console.log(`${cyan}${i18n.step_2}${reset}`);
       console.log(`${cyan}>>> English: "Read .agentic-setup.md and guide me through the setup."${reset}`);
-      console.log(`${cyan}>>> Español: "Lea el archivo .agentic-setup.md e inicie el Setup Mode"${reset}`);
+      console.log(`${cyan}>>> Español: "Lea el arquivo .agentic-setup.md e inicie el Setup Mode"${reset}`);
       console.log(`${cyan}>>> Português: "Leia o arquivo .agentic-setup.md e inicie o Setup Mode."${reset}\n`);
-      console.log(`Note: The agent will clean up the .agentic-setup.md file automatically when finished.\n`);
+      console.log(`${i18n.note_cleanup}`);
     } else {
-      console.error(`❌ Could not find claude instruction file at ${claudeSetupSrc}`);
+      console.error(`${i18n.missing_claude}${claudeSetupSrc}`);
     }
   } else if (agent === 'cursor') {
     if (fs.existsSync(cursorSetupSrc)) {
@@ -85,22 +327,24 @@ rl.question('Which AI Agent will you use for the setup? (e.g. claude, cursor, co
       const setupPromptDest = path.join(targetDir, '.agentic-pdlc', 'SETUP_PROMPT.md');
       if (fs.existsSync(claudeSetupSrc)) fs.copyFileSync(claudeSetupSrc, setupPromptDest);
 
-      console.log(`✅ Default cursor rules written to .cursorrules`);
-      console.log(`✅ Framework Setup Instructions written to .agentic-pdlc/SETUP_PROMPT.md`);
-      console.log(`\n${green}🎉 Done! To start the conversational setup:${reset}`);
-      console.log(`${cyan}\t1. Open Cursor${reset}`);
-      console.log(`${cyan}\t2. Open Composer (Cmd+I or Cmd+L) and type: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"${reset}\n`);
+      console.log(`${i18n.cursor_rules_written}`);
+      console.log(`${i18n.cursor_setup_written}`);
+      console.log(`\n${green}${i18n.cursor_done}${reset}`);
+      console.log(`${cyan}${i18n.cursor_step_1}${reset}`);
+      console.log(`${cyan}${i18n.cursor_step_2}${reset}`);
     } else {
-      console.error(`❌ Could not find cursor instruction file at ${cursorSetupSrc}`);
+      console.error(`${i18n.missing_claude}${cursorSetupSrc}`);
     }
   } else {
     // Generic fallback mapping
     const dest = path.join(targetDir, '.agentic-setup-prompt.md');
     fs.copyFileSync(claudeSetupSrc, dest);
-    console.log(`✅ Agent generic setup instructions written to .agentic-setup-prompt.md`);
-    console.log(`\n${green}🎉 Done! To start the conversational setup:${reset}`);
-    console.log(`${cyan}Provide the .agentic-setup-prompt.md file to your AI agent and ask it to execute Setup Mode!${reset}\n`);
+    console.log(`${i18n.generic_written}`);
+    console.log(`\n${green}${i18n.cursor_done}${reset}`);
+    console.log(`${cyan}${i18n.generic_done}${reset}`);
   }
 
   rl.close();
-});
+}
+
+runSetup();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -194,17 +194,15 @@ async function runSetup() {
   try {
     execFileSync('gh', ['api', `repos/${repo}/branches/${branchName}/protection`, '--method', 'PUT', '--input', '-'], {
       input: JSON.stringify(protectionPayload),
-      stdio: 'ignore'
+      stdio: ['pipe', 'pipe', 'pipe']
     });
     console.log(`  ${i18n.protection_ok}${branchName}`);
   } catch (err) {
     console.log(`  ${i18n.protection_warn}`);
-    try {
-      const visibility = execFileSync('gh', ['repo', 'view', repo, '--json', 'visibility', '--jq', '.visibility']).toString().trim();
-      if (visibility.toUpperCase() === 'PRIVATE') {
-        console.log(`  ${yellow}Note: Branch protection on Private repos requires GitHub Pro or GitHub Team.${reset}`);
-      }
-    } catch (e) {}
+    if (err.stderr) {
+      const errMsg = err.stderr.toString().trim().split('\n').pop();
+      console.log(`  ${yellow}Detalhes do GitHub: ${errMsg}${reset}`);
+    }
   }
 
   // Project V2

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -202,6 +202,15 @@ async function runSetup() {
     if (err.stderr) {
       const errMsg = err.stderr.toString().trim().split('\n').pop();
       console.log(`  ${yellow}Detalhes do GitHub: ${errMsg}${reset}`);
+      
+      // If the error is a 403 (Upgrade required for private repos)
+      if (errMsg.includes('403') || errMsg.toLowerCase().includes('upgrade')) {
+        console.log(`  ${cyan}👉 Dica: Repositórios privados na conta Gratuita não suportam a API de Branch Protection Clássica.${reset}`);
+        console.log(`  ${cyan}   Opções para resolver:${reset}`);
+        console.log(`  ${cyan}   1. Mude o repositório para Público (totalmente grátis).${reset}`);
+        console.log(`  ${cyan}   2. Configure um "Ruleset" manualmente nas configurações do repositório (grátis para privados).${reset}`);
+        console.log(`  ${cyan}   3. Faça upgrade para o GitHub Pro/Team.${reset}`);
+      }
     }
   }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -104,8 +104,13 @@ function copyDirSync(src, dest) {
 }
 
 function printSetupDone() {
-  console.log(`\n${green}${i18n.setup_done}${reset}`);
-  console.log(`${cyan}${i18n.setup_done_hint}${reset}\n`);
+  const line1 = i18n.setup_done;
+  const line2 = i18n.setup_done_hint;
+  const sep = '='.repeat(Math.max(line1.length, line2.length));
+  console.log(`\n${green}${sep}${reset}`);
+  console.log(`${green}${line1}${reset}`);
+  console.log(`${cyan}${line2}${reset}`);
+  console.log(`${green}${sep}${reset}\n`);
 }
 
 async function runSetup() {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -72,7 +72,9 @@ const i18n = {
   cursor_step_1: t('\t1. Open Cursor', '\t1. Abra o Cursor', '\t1. Abre Cursor'),
   cursor_step_2: t('\t2. Open Composer (Cmd+I or Cmd+L) and type: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n', '\t2. Abra o Composer (Cmd+I ou Cmd+L) e digite: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n', '\t2. Abre Composer (Cmd+I o Cmd+L) y escribe: "@.agentic-pdlc/SETUP_PROMPT.md execute Setup Mode"\n'),
   generic_written: t('✅ Agent generic setup instructions written to .agentic-setup.md', '✅ Instruções genéricas salvas em .agentic-setup.md', '✅ Instrucciones genéricas guardadas en .agentic-setup.md'),
-  generic_done: t('Tell your AI agent to read and execute the .agentic-setup.md file!\n', 'Diga ao seu agente para ler e executar o arquivo .agentic-setup.md!\n', '¡Dile a tu agente de IA que lea y ejecute el archivo .agentic-setup.md!\n')
+  generic_done: t('Tell your AI agent to read and execute the .agentic-setup.md file!\n', 'Diga ao seu agente para ler e executar o arquivo .agentic-setup.md!\n', '¡Dile a tu agente de IA que lea y ejecute el archivo .agentic-setup.md!\n'),
+  setup_done: t('🎉 All set! Continue the setup with your agent:', '🎉 Aqui tá pronto! Continue o setup com o seu agente:', '🎉 ¡Listo! Continúa el setup con tu agente:'),
+  setup_done_hint: t('>>> Tell it to read and execute the .agentic-setup.md file!', '>>> Diga a ele para ler e executar o arquivo .agentic-setup.md!', '>>> Dile que lea y ejecute el archivo .agentic-setup.md!')
 };
 
 const cyan = '\x1b[36m';
@@ -99,6 +101,11 @@ function copyDirSync(src, dest) {
       fs.copyFileSync(srcPath, destPath);
     }
   }
+}
+
+function printSetupDone() {
+  console.log(`\n${green}${i18n.setup_done}${reset}`);
+  console.log(`${cyan}${i18n.setup_done_hint}${reset}\n`);
 }
 
 async function runSetup() {
@@ -185,7 +192,7 @@ async function runSetup() {
 
   // Project V2
   console.log(`\n${cyan}${i18n.creating_project}${reset}`);
-  let ownerId, projectId, projectUrl;
+  let ownerId, projectId;
   try {
     if (isOrg) {
       const orgOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=query($login: String!) { organization(login: $login) { id } }', '-f', `login=${repoOwner}`, '--jq', '.data.organization.id']).toString().trim();
@@ -208,13 +215,6 @@ async function runSetup() {
       console.log(`  ${i18n.link_project_warn}`);
     }
 
-    try {
-      const projectNumber = execFileSync('gh', ['api', 'graphql', '-f', `query=query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { number } } }`, '-f', `projectId=${projectId}`, '--jq', '.data.node.number'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-      const ownerSegment = isOrg ? `orgs/${repoOwner}` : `users/${repoOwner}`;
-      projectUrl = `https://github.com/${ownerSegment}/projects/${projectNumber}/views/1?layout=board`;
-    } catch (err) {
-      // URL is optional — main flow continues
-    }
   } catch (err) {
     console.log(`  ${i18n.project_err}${err.message}`);
   }
@@ -323,20 +323,7 @@ async function runSetup() {
       const dest = path.join(targetDir, '.agentic-setup.md');
       fs.copyFileSync(claudeSetupSrc, dest);
       console.log(`${i18n.setup_written}`);
-      const boardMsg = projectUrl
-        ? t(`🎉 Board created, check it out: ${projectUrl}`, `🎉 Board criado, dá uma olhada: ${projectUrl}`, `🎉 Board creado, échale un vistazo: ${projectUrl}`)
-        : i18n.framework_scaffolded;
-      const sep = '='.repeat(boardMsg.length);
-      console.log(`${green}${sep}${reset}`);
-      console.log(`${green}${boardMsg}${reset}`);
-      console.log(`${green}${sep}${reset}\n`);
-      console.log(`${yellow}${i18n.next_steps}${reset}`);
-      console.log(`${cyan}${i18n.step_1}${reset}`);
-      console.log(`${cyan}${i18n.step_2}${reset}`);
-      console.log(`${cyan}>>> English: "Read .agentic-setup.md and guide me through the setup."${reset}`);
-      console.log(`${cyan}>>> Español: "Lea el archivo .agentic-setup.md e inicie el Setup Mode"${reset}`);
-      console.log(`${cyan}>>> Português: "Leia o arquivo .agentic-setup.md e inicie o Setup Mode."${reset}\n`);
-      console.log(`${i18n.note_cleanup}`);
+      printSetupDone();
     } else {
       console.error(`${i18n.missing_claude}${claudeSetupSrc}`);
     }
@@ -352,9 +339,7 @@ async function runSetup() {
 
       console.log(`${i18n.cursor_rules_written}`);
       console.log(`${i18n.cursor_setup_written}`);
-      console.log(`\n${green}${i18n.cursor_done}${reset}`);
-      console.log(`${cyan}${i18n.cursor_step_1}${reset}`);
-      console.log(`${cyan}${i18n.cursor_step_2}${reset}`);
+      printSetupDone();
     } else {
       console.error(`${i18n.missing_claude}${cursorSetupSrc}`);
     }
@@ -363,8 +348,7 @@ async function runSetup() {
     const dest = path.join(targetDir, '.agentic-setup.md');
     fs.copyFileSync(claudeSetupSrc, dest);
     console.log(`${i18n.generic_written}`);
-    console.log(`\n${green}${i18n.cursor_done}${reset}`);
-    console.log(`${cyan}>>> ${i18n.generic_done}${reset}`);
+    printSetupDone();
   }
 
   rl.close();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -63,7 +63,7 @@ const i18n = {
   step_1: t('1. Open your AI Assistant (Claude, Cursor, Copilot, etc).', '1. Abra o seu Assistente de IA (Claude, Cursor, Copilot, etc).', '1. Abre tu Asistente de IA (Claude, Cursor, Copilot, etc).'),
   step_2: t('2. Ask it to read the .agentic-setup.md and start Setup Mode in any language you prefer. Example 👇', '2. Peça para ele ler o .agentic-setup.md e iniciar o Setup Mode. Exemplo 👇', '2. Pídele que lea .agentic-setup.md e inicie el Setup Mode. Ejemplo 👇'),
   note_cleanup: t('Note: The agent will clean up the .agentic-setup.md file automatically when finished.\n', 'Nota: O agente irá limpar o arquivo .agentic-setup.md automaticamente quando terminar.\n', 'Nota: El agente limpiará el archivo .agentic-setup.md automáticamente cuando termine.\n'),
-  missing_claude: t('❌ Could not find claude instruction file at ', '❌ Não foi possível encontrar o arquivo de instrução em ', '❌ No se pudo encontrar el archivo de instrucción en '),
+  missing_claude: t('❌ Could not find instruction file at ', '❌ Não foi possível encontrar o arquivo de instrução em ', '❌ No se pudo encontrar el archivo de instrucción en '),
   cursor_rules_written: t('✅ Default cursor rules written to .cursorrules', '✅ Regras padrão do cursor salvas em .cursorrules', '✅ Reglas por defecto de cursor guardadas en .cursorrules'),
   cursor_setup_written: t('✅ Framework Setup Instructions written to .agentic-pdlc/SETUP_PROMPT.md', '✅ Instruções de Setup do Framework salvas em .agentic-pdlc/SETUP_PROMPT.md', '✅ Instrucciones de Setup del Framework guardadas en .agentic-pdlc/SETUP_PROMPT.md'),
   cursor_done: t('🎉 Done! To start the conversational setup:', '🎉 Pronto! Para iniciar o setup conversacional:', '🎉 ¡Listo! Para iniciar la configuración conversacional:'),

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,13 +42,13 @@ const i18n = {
   ask_org: t('Does this repository belong to a personal User account (e.g., github.com/rafaeltcosta86) or an Organization (e.g., github.com/google-labs)? (user/org): ', 'Esse repositório pertence a um Usuário pessoal (ex: github.com/rafaeltcosta86) ou a uma Organização (ex: github.com/google-labs)? (user/org): ', '¿Este repositorio pertenece a un Usuario personal (ej: github.com/rafaeltcosta86) o a una Organización (ej: github.com/google-labs)? (user/org): '),
   ask_branch: t('What is your main branch name? (default: main): ', 'Qual o nome da sua branch principal? (padrão: main): ', '¿Cuál es el nombre de tu rama principal? (por defecto: main): '),
   starting_setup: t('Starting automated repository setup...', 'Iniciando o setup automatizado do repositório...', 'Iniciando la configuración automatizada del repositorio...'),
-  creating_labels: t('[1/3] Creating repository labels...', '[1/3] Criando labels no repositório...', '[1/3] Creando etiquetas (labels) en el repositorio...'),
+  creating_labels: t('[1/2] Creating repository labels...', '[1/2] Criando labels no repositório...', '[1/2] Creando etiquetas (labels) en el repositorio...'),
   label_ok: t('✅ Label created: ', '✅ Label criada: ', '✅ Etiqueta creada: '),
   label_warn: t('⚠️ Failed to create label (might already exist): ', '⚠️ Falha ao criar label (talvez já exista): ', '⚠️ Fallo al crear etiqueta (quizás ya exista): '),
   applying_protection: t('[2/3] Applying branch protection on ', '[2/3] Aplicando proteção de branch em ', '[2/3] Aplicando protección de rama en '),
   protection_ok: t('✅ Branch protection applied to ', '✅ Proteção de branch aplicada em ', '✅ Protección de rama aplicada a '),
   protection_warn: t('⚠️ Failed to apply branch protection. (Do you have GitHub Pro or is the repo Public?)', '⚠️ Falha ao aplicar proteção de branch. (Você tem GitHub Pro ou o repo é Público?)', '⚠️ Fallo al aplicar protección de rama. (¿Tienes GitHub Pro o el repositorio es Público?)'),
-  creating_project: t('[3/3] Creating Project V2 Board...', '[3/3] Criando Project V2 Board...', '[3/3] Creando Project V2 Board...'),
+  creating_project: t('[2/2] Creating Project V2 Board...', '[2/2] Criando Project V2 Board...', '[2/2] Creando Project V2 Board...'),
   project_ok: t('✅ Project created (ID: ', '✅ Projeto criado (ID: ', '✅ Proyecto creado (ID: '),
   project_err: t('❌ Failed to create project. Error: ', '❌ Falha ao criar o projeto. Erro: ', '❌ Fallo al crear el proyecto. Error: '),
   config_columns: t('Configuring Project Columns...', 'Configurando colunas do Projeto...', 'Configurando columnas del Proyecto...'),
@@ -177,40 +177,6 @@ async function runSetup() {
       console.log(`  ${i18n.label_ok}${label.name}`);
     } catch (err) {
       console.log(`  ${i18n.label_warn}${label.name}`);
-    }
-  }
-
-  // Branch Protection
-  console.log(`\n${cyan}${i18n.applying_protection}'${branchName}'...${reset}`);
-  const protectionPayload = {
-    required_status_checks: { strict: true, checks: [{ context: "Detect Project Board Drift" }] },
-    enforce_admins: false,
-    required_pull_request_reviews: { required_approving_review_count: 1, dismiss_stale_reviews: true },
-    restrictions: null,
-    allow_force_pushes: false,
-    allow_deletions: false
-  };
-
-  try {
-    execFileSync('gh', ['api', `repos/${repo}/branches/${branchName}/protection`, '--method', 'PUT', '--input', '-'], {
-      input: JSON.stringify(protectionPayload),
-      stdio: ['pipe', 'pipe', 'pipe']
-    });
-    console.log(`  ${i18n.protection_ok}${branchName}`);
-  } catch (err) {
-    console.log(`  ${i18n.protection_warn}`);
-    if (err.stderr) {
-      const errMsg = err.stderr.toString().trim().split('\n').pop();
-      console.log(`  ${yellow}Detalhes do GitHub: ${errMsg}${reset}`);
-      
-      // If the error is a 403 (Upgrade required for private repos)
-      if (errMsg.includes('403') || errMsg.toLowerCase().includes('upgrade')) {
-        console.log(`  ${cyan}👉 Dica: Repositórios privados na conta Gratuita não suportam a API de Branch Protection Clássica.${reset}`);
-        console.log(`  ${cyan}   Nota: Essa proteção é opcional (evita commits diretos na main) e não impede o restante do setup!${reset}`);
-        console.log(`  ${cyan}   Se quiser ativar a proteção gratuitamente, você tem duas opções:${reset}`);
-        console.log(`  ${cyan}   1. Mudar o repositório para Público (Settings > Danger Zone).${reset}`);
-        console.log(`  ${cyan}   2. Ou configurar um "Ruleset" manualmente (Settings > Rules > Rulesets), que é a nova funcionalidade grátis do GitHub.${reset}`);
-      }
     }
   }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -120,6 +120,7 @@ async function runSetup() {
   while (true) {
     let repoUrl = (await askQuestion(i18n.ask_repo)).trim();
     if (repoUrl.endsWith('/')) repoUrl = repoUrl.slice(0, -1);
+    if (repoUrl.endsWith('.git')) repoUrl = repoUrl.slice(0, -4);
     const repoParts = repoUrl.split('/');
     if (repoParts.length >= 2) {
       repoOwner = repoParts[repoParts.length - 2];

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,6 +51,8 @@ const i18n = {
   creating_project: t('[2/2] Creating Project V2 Board...', '[2/2] Criando Project V2 Board...', '[2/2] Creando Project V2 Board...'),
   project_ok: t('✅ Project created (ID: ', '✅ Projeto criado (ID: ', '✅ Proyecto creado (ID: '),
   project_err: t('❌ Failed to create project. Error: ', '❌ Falha ao criar o projeto. Erro: ', '❌ Fallo al crear el proyecto. Error: '),
+  link_project_ok: t('✅ Project linked to repository.', '✅ Projeto vinculado ao repositório.', '✅ Proyecto vinculado al repositorio.'),
+  link_project_warn: t('⚠️ Failed to link project to repository. Link it manually in GitHub Projects settings.', '⚠️ Falha ao vincular projeto ao repositório. Faça isso manualmente nas configurações do GitHub Projects.', '⚠️ Fallo al vincular el proyecto al repositorio. Hazlo manualmente en la configuración de GitHub Projects.'),
   config_columns: t('Configuring Project Columns...', 'Configurando colunas do Projeto...', 'Configurando columnas del Proyecto...'),
   columns_ok: t('✅ Project columns configured successfully.', '✅ Colunas do projeto configuradas com sucesso.', '✅ Columnas del proyecto configuradas con éxito.'),
   columns_warn: t('⚠️ Failed to configure project columns. You may need to add them manually.', '⚠️ Falha ao configurar colunas. Você pode precisar adicioná-las manualmente.', '⚠️ Fallo al configurar columnas. Es posible que debas agregarlas manualmente.'),
@@ -197,6 +199,14 @@ async function runSetup() {
     projectId = projectCreateOutput;
 
     console.log(`  ${i18n.project_ok}${projectId})`);
+
+    try {
+      const repoNodeId = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.node_id'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+      execFileSync('gh', ['api', 'graphql', '-f', `query=mutation($projectId: ID!, $repositoryId: ID!) { linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) { repository { name } } }`, '-f', `projectId=${projectId}`, '-f', `repositoryId=${repoNodeId}`], { stdio: 'ignore' });
+      console.log(`  ${i18n.link_project_ok}`);
+    } catch (err) {
+      console.log(`  ${i18n.link_project_warn}`);
+    }
   } catch (err) {
     console.log(`  ${i18n.project_err}${err.message}`);
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -185,7 +185,7 @@ async function runSetup() {
 
   // Project V2
   console.log(`\n${cyan}${i18n.creating_project}${reset}`);
-  let ownerId, projectId;
+  let ownerId, projectId, projectUrl;
   try {
     if (isOrg) {
       const orgOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=query($login: String!) { organization(login: $login) { id } }', '-f', `login=${repoOwner}`, '--jq', '.data.organization.id']).toString().trim();
@@ -206,6 +206,14 @@ async function runSetup() {
       console.log(`  ${i18n.link_project_ok}`);
     } catch (err) {
       console.log(`  ${i18n.link_project_warn}`);
+    }
+
+    try {
+      const projectNumber = execFileSync('gh', ['api', 'graphql', '-f', `query=query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { number } } }`, '-f', `projectId=${projectId}`, '--jq', '.data.node.number'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+      const ownerSegment = isOrg ? `orgs/${repoOwner}` : `users/${repoOwner}`;
+      projectUrl = `https://github.com/${ownerSegment}/projects/${projectNumber}/views/1?layout=board`;
+    } catch (err) {
+      // URL is optional — main flow continues
     }
   } catch (err) {
     console.log(`  ${i18n.project_err}${err.message}`);
@@ -315,9 +323,13 @@ async function runSetup() {
       const dest = path.join(targetDir, '.agentic-setup.md');
       fs.copyFileSync(claudeSetupSrc, dest);
       console.log(`${i18n.setup_written}`);
-      console.log(`${green}============================================================${reset}`);
-      console.log(`${green}${i18n.framework_scaffolded}${reset}`);
-      console.log(`${green}============================================================${reset}\n`);
+      const boardMsg = projectUrl
+        ? t(`🎉 Board created, check it out: ${projectUrl}`, `🎉 Board criado, dá uma olhada: ${projectUrl}`, `🎉 Board creado, échale un vistazo: ${projectUrl}`)
+        : i18n.framework_scaffolded;
+      const sep = '='.repeat(boardMsg.length);
+      console.log(`${green}${sep}${reset}`);
+      console.log(`${green}${boardMsg}${reset}`);
+      console.log(`${green}${sep}${reset}\n`);
       console.log(`${yellow}${i18n.next_steps}${reset}`);
       console.log(`${cyan}${i18n.step_1}${reset}`);
       console.log(`${cyan}${i18n.step_2}${reset}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -223,24 +223,22 @@ async function runSetup() {
           { name: "🚀 Production", description: "Merged", color: "GREEN" }
         ];
 
-        const updateFieldQuery = `mutation($projectId: ID!, $fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+        const updateFieldQuery = `mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
           updateProjectV2Field(input: {
-            projectId: $projectId,
             fieldId: $fieldId,
             singleSelectOptions: $options
-          }) { 
-            projectV2Field { 
+          }) {
+            projectV2Field {
               ... on ProjectV2SingleSelectField {
-                options { id name } 
+                options { id name }
               }
-            } 
+            }
           }
         }`;
 
         const queryPayload = JSON.stringify({
           query: updateFieldQuery,
           variables: {
-            projectId: projectId,
             fieldId: statusFieldId,
             options: columns
           }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -276,10 +276,10 @@ async function runSetup() {
     if (fs.existsSync(pdlcDest)) {
       let pdlcContent = fs.readFileSync(pdlcDest, 'utf8');
       
-      if (projectId) pdlcContent = pdlcContent.replace(/\{\{PROJECT_ID\}\}/g, projectId);
-      if (statusFieldId) pdlcContent = pdlcContent.replace(/\{\{STATUS_FIELD_ID\}\}/g, statusFieldId);
-      pdlcContent = pdlcContent.replace(/\{\{REPO_OWNER\}\}/g, repoOwner);
-      pdlcContent = pdlcContent.replace(/\{\{REPO_NAME\}\}/g, repoName);
+      if (projectId) pdlcContent = pdlcContent.replace(/\\{\\{PROJECT_ID\\}\\}/g, () => projectId);
+      if (statusFieldId) pdlcContent = pdlcContent.replace(/\\{\\{STATUS_FIELD_ID\\}\\}/g, () => statusFieldId);
+      pdlcContent = pdlcContent.replace(/\\{\\{REPO_OWNER\\}\\}/g, () => repoOwner);
+      pdlcContent = pdlcContent.replace(/\\{\\{REPO_NAME\\}\\}/g, () => repoName);
 
       if (Object.keys(optionMap).length > 0) {
         pdlcContent = pdlcContent.replace(/\{\{ID_IDEA\}\}/g, optionMap["💡 Idea"] || 'MISSING_ID');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -212,15 +212,15 @@ async function runSetup() {
 
       if (statusFieldId) {
         const columns = [
-          { name: "💡 Idea", description: "Backlog", color: "GRAY" },
-          { name: "🔍 Exploration", description: "Claude is analyzing", color: "PURPLE" },
-          { name: "🧠 Brainstorming", description: "Awaiting PM gate", color: "PINK" },
-          { name: "📐 Detail Solution", description: "Technical spec", color: "BLUE" },
-          { name: "✅ Approval", description: "Spec ready", color: "GREEN" },
-          { name: "⚙️ Development", description: "Agent implementing", color: "ORANGE" },
-          { name: "🧪 Testing", description: "QA testing", color: "RED" },
-          { name: "👁 Code Review / PR", description: "PR opened", color: "YELLOW" },
-          { name: "🚀 Production", description: "Merged", color: "GREEN" }
+          { name: "💡 Idea", description: "Backlog — every new issue lands here", color: "GRAY" },
+          { name: "🔍 Exploration", description: "AI is analyzing code and context", color: "PURPLE" },
+          { name: "🧠 Brainstorming", description: "AI proposed approaches and trade-offs", color: "PINK" },
+          { name: "📐 Detail Solution", description: "AI is writing the technical spec", color: "BLUE" },
+          { name: "✅ Approval", description: "Spec ready, awaiting `spec:approved` label", color: "GREEN" },
+          { name: "⚙️ Development", description: "AI implementing the spec", color: "ORANGE" },
+          { name: "🧪 Testing", description: "QA testing and CI pipeline checks", color: "RED" },
+          { name: "👁 Code Review / PR", description: "PR opened, awaiting your review", color: "YELLOW" },
+          { name: "🚀 Ready for Production", description: "Merged and ready for production", color: "GREEN" }
         ];
 
         const updateFieldQuery = `mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
@@ -247,7 +247,7 @@ async function runSetup() {
         const updateOutput = execFileSync('gh', ['api', 'graphql', '--input', '-'], { input: queryPayload }).toString().trim();
         const jsonResponse = updateOutput ? JSON.parse(updateOutput) : null;
         const returnedOptions = jsonResponse?.data?.updateProjectV2Field?.projectV2Field?.options || [];
-        
+
         for (const opt of returnedOptions) {
           optionMap[opt.name] = opt.id;
         }
@@ -264,7 +264,7 @@ async function runSetup() {
   // We copy the templates folder so the agent has the real text logic to replace and rename
   const sourceTemplates = path.join(sourceDir, 'templates');
   const targetTemplates = path.join(targetDir, '.agentic-pdlc', 'templates');
-  
+
   if (fs.existsSync(sourceTemplates)) {
     copyDirSync(sourceTemplates, targetTemplates);
     console.log(`${i18n.templates_copied}`);
@@ -273,7 +273,7 @@ async function runSetup() {
     const pdlcDest = path.join(targetTemplates, 'docs', 'pdlc.md');
     if (fs.existsSync(pdlcDest)) {
       let pdlcContent = fs.readFileSync(pdlcDest, 'utf8');
-      
+
       if (projectId) pdlcContent = pdlcContent.replace(/\\{\\{PROJECT_ID\\}\\}/g, () => projectId);
       if (statusFieldId) pdlcContent = pdlcContent.replace(/\\{\\{STATUS_FIELD_ID\\}\\}/g, () => statusFieldId);
       pdlcContent = pdlcContent.replace(/\\{\\{REPO_OWNER\\}\\}/g, () => repoOwner);
@@ -288,7 +288,7 @@ async function runSetup() {
         pdlcContent = pdlcContent.replace(/\{\{ID_DEVELOPMENT\}\}/g, optionMap["⚙️ Development"] || 'MISSING_ID');
         pdlcContent = pdlcContent.replace(/\{\{ID_TESTING\}\}/g, optionMap["🧪 Testing"] || 'MISSING_ID');
         pdlcContent = pdlcContent.replace(/\{\{ID_CODE_REVIEW_PR\}\}/g, optionMap["👁 Code Review / PR"] || 'MISSING_ID');
-        pdlcContent = pdlcContent.replace(/\{\{ID_PRODUCTION\}\}/g, optionMap["🚀 Production"] || 'MISSING_ID');
+        pdlcContent = pdlcContent.replace(/\{\{ID_READY_FOR_PRODUCTION\}\}/g, optionMap["🚀 Ready for Production"] || 'MISSING_ID');
       }
 
       fs.writeFileSync(pdlcDest, pdlcContent);
@@ -323,7 +323,7 @@ async function runSetup() {
       // Create .cursorrules which has the general invariants
       const dest = path.join(targetDir, '.cursorrules');
       fs.copyFileSync(cursorSetupSrc, dest);
-      
+
       // Also copy skill.md as a setup prompt for cursor composer
       const setupPromptDest = path.join(targetDir, '.agentic-pdlc', 'SETUP_PROMPT.md');
       if (fs.existsSync(claudeSetupSrc)) fs.copyFileSync(claudeSetupSrc, setupPromptDest);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -36,7 +36,7 @@ const i18n = {
   gh_ok: t('✅ GitHub CLI is authenticated.', '✅ GitHub CLI está autenticado.', '✅ GitHub CLI está autenticado.'),
   gh_error: t('❌ GitHub CLI (gh) is not installed or not authenticated.', '❌ GitHub CLI (gh) não está instalado ou não autenticado.', '❌ GitHub CLI (gh) no está instalado o no está autenticado.'),
   gh_install: t('Please install it from https://cli.github.com/ and run "gh auth login" before continuing.\n', 'Por favor, instale em https://cli.github.com/ e rode "gh auth login" antes de continuar.\n', 'Por favor, instálalo desde https://cli.github.com/ y ejecuta "gh auth login" antes de continuar.\n'),
-  ask_agent: t('Which AI Agent will you use for the setup? (e.g. claude, cursor, copilot, or other): ', 'Qual Agente de IA você usará para o setup? (ex: claude, cursor, copilot, ou outro): ', '¿Qué Agente de IA usarás para la configuración? (ej: claude, cursor, copilot, u otro): '),
+  ask_agent: t('Which AI Agent will you use for the setup? (e.g. claude, cursor, copilot, antigravity, or other): ', 'Qual Agente de IA você usará para o setup? (ex: claude, cursor, copilot, antigravity, ou outro): ', '¿Qué Agente de IA usarás para la configuración? (ej: claude, cursor, copilot, antigravity, u otro): '),
   ask_repo: t('What is your GitHub repository URL? (e.g., https://github.com/YOUR_USER/repo_name): ', 'Qual é a URL do seu repositório no GitHub? (ex: https://github.com/SEU_USUARIO/repo_name): ', '¿Cuál es la URL de tu repositorio en GitHub? (ej: https://github.com/TU_USUARIO/repo_name): '),
   invalid_repo: t('❌ Invalid repository URL. Expected format: https://github.com/OWNER/REPO', '❌ URL de repositório inválida. Formato esperado: https://github.com/OWNER/REPO', '❌ URL de repositorio inválida. Formato esperado: https://github.com/OWNER/REPO'),
   ask_org: t('Does this repository belong to a personal User account (e.g., github.com/rafaeltcosta86) or an Organization (e.g., github.com/google-labs)? (user/org): ', 'Esse repositório pertence a um Usuário pessoal (ex: github.com/rafaeltcosta86) ou a uma Organização (ex: github.com/google-labs)? (user/org): ', '¿Este repositorio pertenece a un Usuario personal (ej: github.com/rafaeltcosta86) o a una Organización (ej: github.com/google-labs)? (user/org): '),
@@ -113,7 +113,7 @@ async function runSetup() {
   const agentAnswer = await askQuestion(i18n.ask_agent);
   const agent = agentAnswer.trim().toLowerCase();
   if (!['claude', 'cursor', 'copilot'].includes(agent)) {
-    console.log(t(`⚠️ Agent '${agent}' not recognized natively. Will use generic setup.`, `⚠️ Agente '${agent}' não reconhecido nativamente. Usará setup genérico.`, `⚠️ Agente '${agent}' no reconocido nativamente. Usará configuración genérica.`));
+    console.log(t(`ℹ️ Generating Universal Setup for '${agent}' (Compatible with any Markdown-reading agent).`, `ℹ️ Gerando Setup Universal para '${agent}' (Compatível com qualquer agente que leia Markdown).`, `ℹ️ Generando Setup Universal para '${agent}' (Compatible con cualquier agente que lea Markdown).`));
   }
 
   let repoOwner, repoName, repo;
@@ -206,10 +206,10 @@ async function runSetup() {
       // If the error is a 403 (Upgrade required for private repos)
       if (errMsg.includes('403') || errMsg.toLowerCase().includes('upgrade')) {
         console.log(`  ${cyan}👉 Dica: Repositórios privados na conta Gratuita não suportam a API de Branch Protection Clássica.${reset}`);
-        console.log(`  ${cyan}   Opções para resolver:${reset}`);
-        console.log(`  ${cyan}   1. Mude o repositório para Público (totalmente grátis).${reset}`);
-        console.log(`  ${cyan}   2. Configure um "Ruleset" manualmente nas configurações do repositório (grátis para privados).${reset}`);
-        console.log(`  ${cyan}   3. Faça upgrade para o GitHub Pro/Team.${reset}`);
+        console.log(`  ${cyan}   Nota: Essa proteção é opcional (evita commits diretos na main) e não impede o restante do setup!${reset}`);
+        console.log(`  ${cyan}   Se quiser ativar a proteção gratuitamente, você tem duas opções:${reset}`);
+        console.log(`  ${cyan}   1. Mudar o repositório para Público (Settings > Danger Zone).${reset}`);
+        console.log(`  ${cyan}   2. Ou configurar um "Ruleset" manualmente (Settings > Rules > Rulesets), que é a nova funcionalidade grátis do GitHub.${reset}`);
       }
     }
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -138,7 +138,7 @@ async function runSetup() {
 
   let isOrg = false;
   try {
-    const ownerType = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.owner.type']).toString().trim();
+    const ownerType = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.owner.type'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
     isOrg = ownerType === 'Organization';
   } catch (err) {
     const accountTypeAnswer = await askQuestion(i18n.ask_org);
@@ -147,7 +147,7 @@ async function runSetup() {
 
   let branchName = 'main';
   try {
-    branchName = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.default_branch']).toString().trim() || 'main';
+    branchName = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.default_branch'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || 'main';
   } catch (err) {
     const branchAnswer = await askQuestion(i18n.ask_branch);
     if (branchAnswer.trim()) branchName = branchAnswer.trim();

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -5,11 +5,11 @@
 | Column | Meaning | Who moves the card |
 |---|---|---|
 | 💡 Idea | Backlog — every new issue lands here | Manual |
-| 🔍 Exploration | Claude is analyzing code and context | Label `stage:exploration` |
-| 🧠 Brainstorming | Claude proposed approaches, awaiting PM gate | Label `stage:brainstorming` |
-| 📐 Detail Solution | Claude is writing the technical spec | Label `stage:detailing` |
-| ✅ Approval | Spec ready, awaiting `spec:approved` label | Label `spec:approved` |
-| ⚙️ Development | Agent implementing the spec | Label `stage:development` |
+| 🔍 Exploration | AI is analyzing code and context | Label `stage:exploration` |
+| 🧠 Brainstorming | AI proposed approaches and trade-offs | Label `stage:brainstorming` |
+| 📐 Detail Solution | AI is writing the technical spec | Label `stage:detailing` |
+| ✅ Approval | Your turn, awaiting `spec:approved` label | Label `spec:approved` |
+| ⚙️ Development | AI implementing the spec | Label `stage:development` |
 | 🧪 Testing | CI pipeline running | GitHub Actions |
 | 👁 Code Review / PR | PR opened, awaiting human review | GitHub Actions |
 | 🚀 Production | Merged | GitHub Actions |

--- a/scripts/reset-test-project.sh
+++ b/scripts/reset-test-project.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Run from the root of a test project to undo everything npx create-agentic-pdlc creates.
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Resetting agentic-pdlc artifacts in: $(pwd)${NC}\n"
+
+remove() {
+  local target="$1"
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    rm -rf "$target"
+    echo -e "  ${GREEN}removed${NC}  $target"
+  else
+    echo -e "           skipped  $target (not found)"
+  fi
+}
+
+# --- CLI phase ---
+remove .agentic-pdlc
+remove .agentic-setup.md
+remove .cursorrules
+
+# --- Setup Mode phase (agent-generated) ---
+remove AGENTS.md
+remove docs/pdlc.md
+remove .github/workflows/project-automation.yml
+remove .github/workflows/agent-trigger.yml
+remove .github/workflows/ci.yml
+remove .github/workflows/qa-agent.yml
+
+# Clean up empty dirs left behind
+rmdir --ignore-fail-on-non-empty docs 2>/dev/null || true
+rmdir --ignore-fail-on-non-empty .github/workflows 2>/dev/null || true
+rmdir --ignore-fail-on-non-empty .github 2>/dev/null || true
+
+echo -e "\n${GREEN}Done. Run 'npx create-agentic-pdlc' to start fresh.${NC}"

--- a/scripts/reset-test-project.sh
+++ b/scripts/reset-test-project.sh
@@ -11,12 +11,17 @@ echo -e "${YELLOW}Resetting agentic-pdlc artifacts in: $(pwd)${NC}\n"
 
 remove() {
   local target="$1"
-  if [ -e "$target" ] || [ -L "$target" ]; then
-    rm -rf "$target"
-    echo -e "  ${GREEN}removed${NC}  $target"
-  else
+  if [ ! -e "$target" ] && [ ! -L "$target" ]; then
     echo -e "           skipped  $target (not found)"
+    return
   fi
+  # Skip files/dirs tracked by git — they predate the setup run
+  if git ls-files --error-unmatch "$target" &>/dev/null 2>&1; then
+    echo -e "  ${YELLOW}protected${NC} $target (tracked by git — skipping)"
+    return
+  fi
+  rm -rf "$target"
+  echo -e "  ${GREEN}removed${NC}  $target"
 }
 
 # --- CLI phase ---

--- a/templates/docs/pdlc.md
+++ b/templates/docs/pdlc.md
@@ -12,11 +12,11 @@
 | ⚙️ Development | Agent implementing the spec | Label `stage:development` |
 | 🧪 Testing | CI pipeline or AI QA Agent running (Variant B) | GitHub Actions / QA Agent |
 | 👁 Code Review / PR | PR opened (Variant A) or QA passed (Variant B) | GitHub Actions |
-| 🚀 Production | Merged | GitHub Actions |
+| 🚀 Ready for Production | Merged | GitHub Actions |
 
 <!--
 Adapt columns as needed. The functional baseline is:
-💡 Idea → ⚙️ Development → 👁 Code Review / PR → 🚀 Production
+💡 Idea → ⚙️ Development → 👁 Code Review / PR → 🚀 Ready for Production
 -->
 
 ## Workflow Variants (QA Agent)
@@ -44,7 +44,7 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | ⚙️ Development | `{{ID_DEVELOPMENT}}` |
 | 🧪 Testing | `{{ID_TESTING}}` |
 | 👁 Code Review / PR | `{{ID_CODE_REVIEW_PR}}` |
-| 🚀 Production | `{{ID_PRODUCTION}}` |
+| 🚀 Ready for Production | `{{ID_READY_FOR_PRODUCTION}}` |
 
 ## Agent × Phase Mapping
 


### PR DESCRIPTION
## Summary

- **Fix:** Remove `projectId` from `updateProjectV2Field` mutation — GitHub removed this argument from `UpdateProjectV2FieldInput`
- **Fix:** Call `linkProjectV2ToRepository` after project creation so the board appears under the repo's Projects tab
- **Fix:** Suppress stderr in `gh api` calls that have graceful fallbacks (cleaner UX)
- **Refactor:** Rename `🚀 Production` column to `🚀 Ready for Production` across CLI, templates, and docs
- **Refactor:** Replace all per-agent divergent final messages with a single unified `printSetupDone()` call (EN/PT/ES)
- **Chore:** Add `scripts/reset-test-project.sh` to wipe CLI/Setup Mode artifacts for clean retesting; protects git-tracked files from accidental deletion

## Test plan

- [ ] Run `node bin/cli.js` through full flow — all 9 columns created, board linked to repo, board visible under repo Projects tab
- [ ] Run with `claude`, `cursor`, and a generic agent — all show same final success message
- [ ] Run `scripts/reset-test-project.sh` in a test project — only untracked files removed, pre-existing tracked files preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)