### PR TITLE
feat(metrics): Agentic Metrics — Weekly Markdown Report (Milestone 1)

### DIFF
--- a/.agentic-pdlc/metrics/2026-W19.md
+++ b/.agentic-pdlc/metrics/2026-W19.md
@@ -1,0 +1,16 @@
+# Agentic Metrics — 2026-W19
+
+> Métricas agentic-specific geradas automaticamente pelo [agentic-pdlc](https://github.com/rafaeltcosta86/agentic-pdlc).
+
+## 🔄 Stage Residence Time
+
+Tempo médio que issues passaram em cada fase do PDLC esta semana (transições completas).
+
+| Stage | Avg | N | vs semana passada |
+|---|---|---|---|
+| — | N/A — sem dados esta semana | — | — |
+
+> **Insight:** Sem transições de stage registradas esta semana.
+
+---
+*Gerado em 2026-05-09 · [Ver histórico](.)*

--- a/.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml
@@ -1,0 +1,108 @@
+name: Agentic Metrics — Weekly Report
+
+on:
+  schedule:
+    - cron: '0 8 * * 0' # Sunday 8am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  generate-report:
+    name: Generate Weekly Agentic Metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Collect Stage Residence Time
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const { owner, repo } = context.repo;
+            const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+            const STAGE_LABELS = new Set([
+              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:approval', 'stage:development', 'stage:testing'
+            ]);
+
+            const QUERY = `
+              query($owner: String!, $repo: String!, $since: DateTime!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  issues(first: 50, after: $cursor, filterBy: { since: $since }) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      number
+                      timelineItems(first: 100, itemTypes: [LABELED_EVENT, UNLABELED_EVENT]) {
+                        nodes {
+                          ... on LabeledEvent   { __typename createdAt label { name } }
+                          ... on UnlabeledEvent { __typename createdAt label { name } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const records = [];
+            let cursor = null;
+            do {
+              const result = await github.graphql(QUERY, { owner, repo, since, cursor });
+              const { nodes, pageInfo } = result.repository.issues;
+
+              for (const issue of nodes) {
+                const events = issue.timelineItems.nodes
+                  .filter(e => e.label && STAGE_LABELS.has(e.label.name))
+                  .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+
+                const labeledAt = {};
+                for (const ev of events) {
+                  const stage = ev.label.name;
+                  if (ev.__typename === 'LabeledEvent') {
+                    labeledAt[stage] = new Date(ev.createdAt);
+                  } else if (ev.__typename === 'UnlabeledEvent' && labeledAt[stage]) {
+                    const durationDays = Math.round((new Date(ev.createdAt) - labeledAt[stage]) / 864e5 * 10) / 10;
+                    records.push({ issueNumber: issue.number, stage, durationDays });
+                    delete labeledAt[stage];
+                  }
+                }
+              }
+
+              cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+            } while (cursor);
+
+            // ISO week helper
+            function isoWeek(d) {
+              const dt = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+              dt.setUTCDate(dt.getUTCDate() + 4 - (dt.getUTCDay() || 7));
+              const y = new Date(Date.UTC(dt.getUTCFullYear(), 0, 1));
+              return { year: dt.getUTCFullYear(), week: Math.ceil((((dt - y) / 86400000) + 1) / 7) };
+            }
+
+            const { year, week } = isoWeek(new Date());
+            const weekKey = `${year}-W${String(week).padStart(2, '0')}`;
+
+            fs.mkdirSync('.agentic-pdlc/metrics/raw', { recursive: true });
+            fs.writeFileSync(
+              `.agentic-pdlc/metrics/raw/${weekKey}.jsonl`,
+              records.map(r => JSON.stringify(r)).join('\n')
+            );
+
+            core.exportVariable('WEEK_KEY', weekKey);
+            console.log(`Collected ${records.length} stage transitions → week ${weekKey}`);
+
+      - name: Generate Markdown Report
+        run: node scripts/aggregate-metrics.js
+
+      - name: Commit Report
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .agentic-pdlc/metrics/
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "metrics: weekly report ${WEEK_KEY} [skip ci]"
+          git push

--- a/.github/workflows/agentic-metrics.yml
+++ b/.github/workflows/agentic-metrics.yml
@@ -1,0 +1,108 @@
+name: Agentic Metrics — Weekly Report
+
+on:
+  schedule:
+    - cron: '0 8 * * 0' # Sunday 8am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  generate-report:
+    name: Generate Weekly Agentic Metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Collect Stage Residence Time
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const { owner, repo } = context.repo;
+            const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+            const STAGE_LABELS = new Set([
+              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:approval', 'stage:development', 'stage:testing'
+            ]);
+
+            const QUERY = `
+              query($owner: String!, $repo: String!, $since: DateTime!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  issues(first: 50, after: $cursor, filterBy: { since: $since }) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      number
+                      timelineItems(first: 100, itemTypes: [LABELED_EVENT, UNLABELED_EVENT]) {
+                        nodes {
+                          ... on LabeledEvent   { __typename createdAt label { name } }
+                          ... on UnlabeledEvent { __typename createdAt label { name } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const records = [];
+            let cursor = null;
+            do {
+              const result = await github.graphql(QUERY, { owner, repo, since, cursor });
+              const { nodes, pageInfo } = result.repository.issues;
+
+              for (const issue of nodes) {
+                const events = issue.timelineItems.nodes
+                  .filter(e => e.label && STAGE_LABELS.has(e.label.name))
+                  .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+
+                const labeledAt = {};
+                for (const ev of events) {
+                  const stage = ev.label.name;
+                  if (ev.__typename === 'LabeledEvent') {
+                    labeledAt[stage] = new Date(ev.createdAt);
+                  } else if (ev.__typename === 'UnlabeledEvent' && labeledAt[stage]) {
+                    const durationDays = Math.round((new Date(ev.createdAt) - labeledAt[stage]) / 864e5 * 10) / 10;
+                    records.push({ issueNumber: issue.number, stage, durationDays });
+                    delete labeledAt[stage];
+                  }
+                }
+              }
+
+              cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+            } while (cursor);
+
+            // ISO week helper
+            function isoWeek(d) {
+              const dt = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+              dt.setUTCDate(dt.getUTCDate() + 4 - (dt.getUTCDay() || 7));
+              const y = new Date(Date.UTC(dt.getUTCFullYear(), 0, 1));
+              return { year: dt.getUTCFullYear(), week: Math.ceil((((dt - y) / 86400000) + 1) / 7) };
+            }
+
+            const { year, week } = isoWeek(new Date());
+            const weekKey = `${year}-W${String(week).padStart(2, '0')}`;
+
+            fs.mkdirSync('.agentic-pdlc/metrics/raw', { recursive: true });
+            fs.writeFileSync(
+              `.agentic-pdlc/metrics/raw/${weekKey}.jsonl`,
+              records.map(r => JSON.stringify(r)).join('\n')
+            );
+
+            core.exportVariable('WEEK_KEY', weekKey);
+            console.log(`Collected ${records.length} stage transitions → week ${weekKey}`);
+
+      - name: Generate Markdown Report
+        run: node scripts/aggregate-metrics.js
+
+      - name: Commit Report
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .agentic-pdlc/metrics/
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "metrics: weekly report ${WEEK_KEY} [skip ci]"
+          git push

--- a/SETUP.md
+++ b/SETUP.md
@@ -149,6 +149,42 @@ If you don't use this, you can safely delete `templates/.github/workflows/qa-age
 
 ---
 
+## (Optional) Agentic Metrics — Weekly Report
+
+Activate a weekly automated report with agentic-specific metrics that no off-the-shelf tool provides:
+
+- **Stage Residence Time** — how long issues spend in each PDLC phase (where your flow stalls)
+- **Agent Rework Rate** — commits added after Jules' first push (agent assertiveness) _(Milestone 2)_
+- **HITL Factor** — human interventions per issue lifecycle (real autonomy measure) _(Milestone 2)_
+
+The report is committed automatically every Sunday to `.agentic-pdlc/metrics/YYYY-WW.md` — visible directly in the GitHub UI, zero extra setup.
+
+**To activate:**
+
+1. Copy the workflow to your repository:
+   ```bash
+   cp .agentic-pdlc/templates/.github/workflows/agentic-metrics.yml .github/workflows/agentic-metrics.yml
+   ```
+
+2. Copy the aggregation script:
+   ```bash
+   cp scripts/aggregate-metrics.js scripts/aggregate-metrics.js
+   ```
+
+3. Ensure the metrics directory exists:
+   ```bash
+   mkdir -p .agentic-pdlc/metrics/raw
+   ```
+
+4. Commit and push. The first report runs next Sunday, or trigger it manually:
+   ```bash
+   gh workflow run agentic-metrics.yml
+   ```
+
+> **No additional secrets needed.** The workflow uses the standard `GITHUB_TOKEN`.
+
+---
+
 ## Final Verification Checklist
 
 - [ ] Board has 10 columns fully configured

--- a/scripts/aggregate-metrics.js
+++ b/scripts/aggregate-metrics.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function isoWeekKey(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const y = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil((((d - y) / 86400000) + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+function prevKey(key) {
+  const [yr, wStr] = key.split('-W');
+  const w = parseInt(wStr, 10);
+  return w > 1 ? `${yr}-W${String(w - 1).padStart(2, '0')}` : `${parseInt(yr, 10) - 1}-W52`;
+}
+
+function avg(arr) {
+  return arr.length ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length * 10) / 10 : null;
+}
+
+function readJsonl(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
+}
+
+function groupByStage(records) {
+  const map = {};
+  for (const r of records) {
+    if (!map[r.stage]) map[r.stage] = [];
+    map[r.stage].push(r.durationDays);
+  }
+  return map;
+}
+
+const weekKey = process.env.WEEK_KEY || isoWeekKey(new Date());
+const metricsDir = path.join(process.cwd(), '.agentic-pdlc', 'metrics');
+const rawDir = path.join(metricsDir, 'raw');
+
+const current = groupByStage(readJsonl(path.join(rawDir, `${weekKey}.jsonl`)));
+const previous = groupByStage(readJsonl(path.join(rawDir, `${prevKey(weekKey)}.jsonl`)));
+
+const STAGES = [
+  ['stage:exploration',   'Exploration'],
+  ['stage:brainstorming', 'Brainstorming'],
+  ['stage:detailing',     'Detailing'],
+  ['stage:approval',      'Approval'],
+  ['stage:development',   'Development'],
+  ['stage:testing',       'Testing'],
+];
+
+const rows = [];
+let bottleneck = null;
+let bottleneckDays = 0;
+
+for (const [stage, label] of STAGES) {
+  const a = avg(current[stage] || []);
+  if (a === null) continue;
+  const p = avg(previous[stage] || []);
+  const n = (current[stage] || []).length;
+  const trend = p == null ? '—'
+    : a > p  ? `⬆ +${Math.round((a - p) * 10) / 10}d`
+    : a < p  ? `⬇ ${Math.round((a - p) * 10) / 10}d`
+    : '→ igual';
+  rows.push(`| **${label}** | ${a}d | ${n} issue${n !== 1 ? 's' : ''} | ${trend} |`);
+  if (a > bottleneckDays) { bottleneck = label; bottleneckDays = a; }
+}
+
+const tableBody = rows.length
+  ? rows.join('\n')
+  : '| — | N/A — sem dados esta semana | — | — |';
+
+const insight = bottleneck
+  ? `> **Insight:** \`${bottleneck}\` é o maior gargalo (${bottleneckDays}d avg). Issues acumulam aqui. Considere quebrar specs ou aumentar cadência de revisão nessa fase.`
+  : '> **Insight:** Sem transições de stage registradas esta semana.';
+
+const md = `# Agentic Metrics — ${weekKey}
+
+> Métricas agentic-specific geradas automaticamente pelo [agentic-pdlc](https://github.com/rafaeltcosta86/agentic-pdlc).
+
+## 🔄 Stage Residence Time
+
+Tempo médio que issues passaram em cada fase do PDLC esta semana (transições completas).
+
+| Stage | Avg | N | vs semana passada |
+|---|---|---|---|
+${tableBody}
+
+${insight}
+
+---
+*Gerado em ${new Date().toISOString().split('T')[0]} · [Ver histórico](.)*
+`;
+
+fs.mkdirSync(metricsDir, { recursive: true });
+const outputFile = path.join(metricsDir, `${weekKey}.md`);
+fs.writeFileSync(outputFile, md);
+console.log(`✅ Report: ${outputFile}`);


### PR DESCRIPTION
## Summary

- Adds `agentic-metrics.yml` workflow (cron Sunday 8am UTC + `workflow_dispatch`) that collects Stage Residence Time via GraphQL Issue Timeline API
- `scripts/aggregate-metrics.js` aggregates raw JSONL → markdown with bottleneck insight + week-over-week comparison
- Template copy in `.agentic-pdlc/templates/` for user repos
- `SETUP.md` updated com seção `(Optional) Agentic Metrics`

## Como funciona

```
GitHub Issue Timeline (GraphQL LabeledEvent/UnlabeledEvent)
  → .agentic-pdlc/metrics/raw/YYYY-WW.jsonl
  → aggregate-metrics.js
  → .agentic-pdlc/metrics/YYYY-WW.md (committed automaticamente)
```

Sem secrets adicionais. Usa `GITHUB_TOKEN`. Zero dependências externas.

## Test plan

- [ ] `gh workflow run agentic-metrics.yml` — sem erros no Actions log
- [ ] `.agentic-pdlc/metrics/YYYY-WW.md` commitado automaticamente
- [ ] Com issues reais: Stage Residence Time mostra dias + N
- [ ] Sem issues esta semana: exibe "N/A — sem dados" sem quebrar

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)