### PR TITLE
feat: PDLC stage gate — 3-layer enforcement with hotfix bypass

### DIFF
--- a/.agentic-pdlc/hooks/pdlc-stage-gate.sh
+++ b/.agentic-pdlc/hooks/pdlc-stage-gate.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PDLC Stage Gate — blocks gh pr create without stage:approval on linked issue.
+# Bypass: branch prefix hotfix/ skips all checks.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('command',''))" 2>/dev/null || echo "")
+
+if ! echo "$COMMAND" | grep -q "gh pr create"; then
+  exit 0
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+if echo "$BRANCH" | grep -qE "^hotfix/"; then
+  echo "✅ PDLC: Hotfix branch — stage gate bypassed."
+  exit 0
+fi
+
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | head -1)
+
+if [ -z "$ISSUE_NUM" ]; then
+  echo "❌ PDLC Stage Gate: Cannot determine issue from branch '$BRANCH'."
+  echo "   Use: feat/<issue-number>-<description> or hotfix/<issue-number>-<description>"
+  exit 1
+fi
+
+LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+
+if echo "$LABELS" | grep -qw "stage:approval"; then
+  echo "✅ PDLC: Issue #$ISSUE_NUM approved — gate passed."
+  exit 0
+fi
+
+STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
+echo "❌ PDLC Stage Gate: Issue #$ISSUE_NUM is not approved."
+echo "   Current stage: $STAGE"
+echo "   Required: stage:approval label on the issue."
+echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
+exit 1

--- a/.agentic-pdlc/hooks/pdlc-stage-gate.sh
+++ b/.agentic-pdlc/hooks/pdlc-stage-gate.sh
@@ -3,7 +3,7 @@
 # Bypass: branch prefix hotfix/ skips all checks.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('command',''))" 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | node -e "const d=JSON.parse(require('fs').readFileSync(0)); console.log(d.command || '')" 2>/dev/null || echo "")
 
 if ! echo "$COMMAND" | grep -q "gh pr create"; then
   exit 0

--- a/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
@@ -1,0 +1,50 @@
+name: PDLC Stage Gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+  issues: read
+
+jobs:
+  stage-gate:
+    name: PDLC Stage Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check stage:approval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(" ")')
+          if echo "$PR_LABELS" | grep -qw "hotfix"; then
+            echo "✅ Hotfix label — stage gate bypassed."
+            exit 0
+          fi
+
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oiE '(Closes?|Fixes?|Resolves?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
+
+          if [ -z "$ISSUE_NUMS" ]; then
+            echo "❌ No linked issues in PR body."
+            echo "   Add 'Closes #N' to PR body, or add 'hotfix' label to PR for emergencies."
+            exit 1
+          fi
+
+          for NUM in $ISSUE_NUMS; do
+            LABELS=$(gh issue view "$NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+            if echo "$LABELS" | grep -qw "stage:approval"; then
+              echo "✅ Issue #$NUM has stage:approval"
+            else
+              STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
+              echo "❌ Issue #$NUM missing stage:approval (current: $STAGE)"
+              echo "   Move through stages: exploration → brainstorming → detailing → approval"
+              echo "   Emergency bypass: add 'hotfix' label to this PR."
+              exit 1
+            fi
+          done
+
+          echo "✅ All linked issues approved."

--- a/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
@@ -17,15 +17,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
+          REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(" ")')
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
           if echo "$PR_LABELS" | grep -qw "hotfix"; then
             echo "✅ Hotfix label — stage gate bypassed."
             exit 0
           fi
 
-          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""')
           ISSUE_NUMS=$(echo "$PR_BODY" | grep -oiE '(Closes?|Fixes?|Resolves?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
 
           if [ -z "$ISSUE_NUMS" ]; then
@@ -35,7 +36,7 @@ jobs:
           fi
 
           for NUM in $ISSUE_NUMS; do
-            LABELS=$(gh issue view "$NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+            LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
             if echo "$LABELS" | grep -qw "stage:approval"; then
               echo "✅ Issue #$NUM has stage:approval"
             else

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .agentic-pdlc/hooks/pdlc-stage-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/pdlc-stage-gate.yml
+++ b/.github/workflows/pdlc-stage-gate.yml
@@ -1,0 +1,50 @@
+name: PDLC Stage Gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+  issues: read
+
+jobs:
+  stage-gate:
+    name: PDLC Stage Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check stage:approval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(" ")')
+          if echo "$PR_LABELS" | grep -qw "hotfix"; then
+            echo "✅ Hotfix label — stage gate bypassed."
+            exit 0
+          fi
+
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oiE '(Closes?|Fixes?|Resolves?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
+
+          if [ -z "$ISSUE_NUMS" ]; then
+            echo "❌ No linked issues in PR body."
+            echo "   Add 'Closes #N' to PR body, or add 'hotfix' label to PR for emergencies."
+            exit 1
+          fi
+
+          for NUM in $ISSUE_NUMS; do
+            LABELS=$(gh issue view "$NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+            if echo "$LABELS" | grep -qw "stage:approval"; then
+              echo "✅ Issue #$NUM has stage:approval"
+            else
+              STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
+              echo "❌ Issue #$NUM missing stage:approval (current: $STAGE)"
+              echo "   Move through stages: exploration → brainstorming → detailing → approval"
+              echo "   Emergency bypass: add 'hotfix' label to this PR."
+              exit 1
+            fi
+          done
+
+          echo "✅ All linked issues approved."

--- a/.github/workflows/pdlc-stage-gate.yml
+++ b/.github/workflows/pdlc-stage-gate.yml
@@ -17,15 +17,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
+          REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(" ")')
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
           if echo "$PR_LABELS" | grep -qw "hotfix"; then
             echo "✅ Hotfix label — stage gate bypassed."
             exit 0
           fi
 
-          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""')
           ISSUE_NUMS=$(echo "$PR_BODY" | grep -oiE '(Closes?|Fixes?|Resolves?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
 
           if [ -z "$ISSUE_NUMS" ]; then
@@ -35,7 +36,7 @@ jobs:
           fi
 
           for NUM in $ISSUE_NUMS; do
-            LABELS=$(gh issue view "$NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+            LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
             if echo "$LABELS" | grep -qw "stage:approval"; then
               echo "✅ Issue #$NUM has stage:approval"
             else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# PDLC Stage Gate
+
+NEVER run `gh pr create` unless one of these is true:
+- The linked issue has label `stage:approval`
+- The branch name starts with `hotfix/`
+
+Advance stages first: `exploration` → `brainstorming` → `detailing` → `approval`
+
+The PreToolUse hook will block the action automatically if this rule is violated.

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -98,6 +98,19 @@ These label commands are non-negotiable. They run **before** the activity they a
 
 No investigation, no skill invocation, no code reading happens before `stage:exploration` is applied. No architecture presentation starts before `stage:brainstorming` is set (and `stage:exploration` removed). No spec writing starts before `stage:detailing` is set (and `stage:brainstorming` removed).
 
+### 0.1 PR Stage Gate — Non-Negotiable
+
+**NEVER run `gh pr create` unless the linked issue has label `stage:approval`.**
+
+The PreToolUse hook enforces this automatically and will block the command. The only bypass is a branch prefixed with `hotfix/` — which requires explicit PM instruction, never agent self-authorization.
+
+Hotfix flow (only when PM explicitly requests it):
+```bash
+gh issue edit <N> --add-label "hotfix"
+git checkout -b hotfix/<N>-<description>
+# implement → gh pr create --label hotfix
+```
+
 ### 1. Daily Upstream Loop
 Your job is to move issues from "Idea" to "Detail Solution".
 When asked to work on a feature, you will:

--- a/adapters/hooks/pdlc-stage-gate.sh
+++ b/adapters/hooks/pdlc-stage-gate.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PDLC Stage Gate — blocks gh pr create without stage:approval on linked issue.
+# Bypass: branch prefix hotfix/ skips all checks.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('command',''))" 2>/dev/null || echo "")
+
+if ! echo "$COMMAND" | grep -q "gh pr create"; then
+  exit 0
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+if echo "$BRANCH" | grep -qE "^hotfix/"; then
+  echo "✅ PDLC: Hotfix branch — stage gate bypassed."
+  exit 0
+fi
+
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | head -1)
+
+if [ -z "$ISSUE_NUM" ]; then
+  echo "❌ PDLC Stage Gate: Cannot determine issue from branch '$BRANCH'."
+  echo "   Use: feat/<issue-number>-<description> or hotfix/<issue-number>-<description>"
+  exit 1
+fi
+
+LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+
+if echo "$LABELS" | grep -qw "stage:approval"; then
+  echo "✅ PDLC: Issue #$ISSUE_NUM approved — gate passed."
+  exit 0
+fi
+
+STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
+echo "❌ PDLC Stage Gate: Issue #$ISSUE_NUM is not approved."
+echo "   Current stage: $STAGE"
+echo "   Required: stage:approval label on the issue."
+echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
+exit 1

--- a/adapters/hooks/pdlc-stage-gate.sh
+++ b/adapters/hooks/pdlc-stage-gate.sh
@@ -3,7 +3,7 @@
 # Bypass: branch prefix hotfix/ skips all checks.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('command',''))" 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | node -e "const d=JSON.parse(require('fs').readFileSync(0)); console.log(d.command || '')" 2>/dev/null || echo "")
 
 if ! echo "$COMMAND" | grep -q "gh pr create"; then
   exit 0

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -343,6 +343,29 @@ async function runSetup() {
     // Non-fatal — agent will ask for the values instead
   }
 
+  // Install PDLC stage gate hook (all agents)
+  const hookSrc = path.join(sourceDir, 'adapters', 'hooks', 'pdlc-stage-gate.sh');
+  const hookDir = path.join(targetDir, '.agentic-pdlc', 'hooks');
+  const hookDest = path.join(hookDir, 'pdlc-stage-gate.sh');
+  if (fs.existsSync(hookSrc)) {
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.copyFileSync(hookSrc, hookDest);
+    fs.chmodSync(hookDest, '755');
+  }
+  const claudeSettingsDir = path.join(targetDir, '.claude');
+  const claudeSettingsPath = path.join(claudeSettingsDir, 'settings.json');
+  if (!fs.existsSync(claudeSettingsPath)) {
+    fs.mkdirSync(claudeSettingsDir, { recursive: true });
+    fs.writeFileSync(claudeSettingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          matcher: 'Bash',
+          hooks: [{ type: 'command', command: 'bash .agentic-pdlc/hooks/pdlc-stage-gate.sh' }]
+        }]
+      }
+    }, null, 2) + '\n');
+  }
+
   // Handle the specific setup instructions target
   const claudeSetupSrc = path.join(sourceDir, 'adapters', 'claude-code', 'skill.md');
   const cursorSetupSrc = path.join(sourceDir, 'adapters', 'cursor', 'rules.md');

--- a/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/templates/.github/workflows/pdlc-stage-gate.yml
@@ -1,0 +1,50 @@
+name: PDLC Stage Gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+  issues: read
+
+jobs:
+  stage-gate:
+    name: PDLC Stage Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check stage:approval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(" ")')
+          if echo "$PR_LABELS" | grep -qw "hotfix"; then
+            echo "✅ Hotfix label — stage gate bypassed."
+            exit 0
+          fi
+
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oiE '(Closes?|Fixes?|Resolves?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
+
+          if [ -z "$ISSUE_NUMS" ]; then
+            echo "❌ No linked issues in PR body."
+            echo "   Add 'Closes #N' to PR body, or add 'hotfix' label to PR for emergencies."
+            exit 1
+          fi
+
+          for NUM in $ISSUE_NUMS; do
+            LABELS=$(gh issue view "$NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+            if echo "$LABELS" | grep -qw "stage:approval"; then
+              echo "✅ Issue #$NUM has stage:approval"
+            else
+              STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
+              echo "❌ Issue #$NUM missing stage:approval (current: $STAGE)"
+              echo "   Move through stages: exploration → brainstorming → detailing → approval"
+              echo "   Emergency bypass: add 'hotfix' label to this PR."
+              exit 1
+            fi
+          done
+
+          echo "✅ All linked issues approved."

--- a/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/templates/.github/workflows/pdlc-stage-gate.yml
@@ -17,15 +17,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
+          REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(" ")')
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
           if echo "$PR_LABELS" | grep -qw "hotfix"; then
             echo "✅ Hotfix label — stage gate bypassed."
             exit 0
           fi
 
-          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body // ""')
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""')
           ISSUE_NUMS=$(echo "$PR_BODY" | grep -oiE '(Closes?|Fixes?|Resolves?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
 
           if [ -z "$ISSUE_NUMS" ]; then
@@ -35,7 +36,7 @@ jobs:
           fi
 
           for NUM in $ISSUE_NUMS; do
-            LABELS=$(gh issue view "$NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+            LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
             if echo "$LABELS" | grep -qw "stage:approval"; then
               echo "✅ Issue #$NUM has stage:approval"
             else


### PR DESCRIPTION
## Summary

Impede que agentes criem PRs sem aprovação do PM (`stage:approval`). Funciona no dogfood repo e propaga para repos de usuários via `cli.js`.

## 3 Camadas

| Camada | Mecanismo | Força |
|---|---|---|
| 1 | `CLAUDE.md` — regra soft | Advisory |
| 2 | `PreToolUse` hook — bloqueia `gh pr create` | Bloqueia no terminal |
| 3 | CI `pdlc-stage-gate.yml` — falha o check | Hard gate (impede merge) |

## Hotfix bypass

Branch `hotfix/` ou label `hotfix` no PR bypassa todas as camadas. Requer instrução explícita do PM — agente não pode se auto-autorizar.

## Arquivos

**Dogfood:**
- `CLAUDE.md` — regra Layer 1
- `.agentic-pdlc/hooks/pdlc-stage-gate.sh` — hook script
- `.claude/settings.json` — registra o hook no Claude Code
- `.github/workflows/pdlc-stage-gate.yml` — CI hard gate

**Templates (propagam para usuários):**
- `adapters/hooks/pdlc-stage-gate.sh` — fonte copiada pelo cli.js
- `templates/.github/workflows/pdlc-stage-gate.yml`
- `.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml`

**Modificados:**
- `bin/cli.js` — instala hook + `.claude/settings.json` para todos os agentes
- `adapters/claude-code/skill.md` — seção 0.1 com regra explícita

## Verificação meta

Este PR deve **passar** no `pdlc-stage-gate` CI — a issue #69 tem `stage:approval`.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)