### PR TITLE
feat: PDLC stage gate — 3-layer enforcement with hotfix bypass

### DIFF
--- a/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
@@ -18,14 +18,13 @@ jobs:
       contents: read
     steps:
       - name: Update Labels
-        if: ${{ !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
-            
+
             try {
               await github.rest.issues.removeLabel({
                 owner,
@@ -36,12 +35,16 @@ jobs:
             } catch (error) {
               console.log('Label stage:approval not found or could not be removed');
             }
-            
+
+            const agentLabel = '{{IMPLEMENTATION_AGENT_LABEL}}';
+            const labelsToAdd = ['stage:development', 'agent:working'];
+            if (!agentLabel.includes('{{')) labelsToAdd.push(agentLabel);
+
             await github.rest.issues.addLabels({
               owner,
               repo,
               issue_number,
-              labels: ['stage:development', '{{IMPLEMENTATION_AGENT_LABEL}}', 'agent:working']
+              labels: labelsToAdd
             });
 
       - name: Comment on issue to trigger agent and prevent race conditions

--- a/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
@@ -37,8 +37,8 @@ jobs:
             }
 
             const agentLabel = '{{IMPLEMENTATION_AGENT_LABEL}}';
-            const labelsToAdd = ['stage:development', 'agent:working'];
-            if (!agentLabel.includes('{{')) labelsToAdd.push(agentLabel);
+            const labelsToAdd = ['stage:development'];
+            if (!agentLabel.includes('{{')) labelsToAdd.push(agentLabel, 'agent:working');
 
             await github.rest.issues.addLabels({
               owner,

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -8,26 +8,22 @@ on:
 
 jobs:
   trigger-implementation-agent:
-    name: Trigger {{IMPLEMENTATION_AGENT_NAME}} for implementation
+    name: Advance issue to stage:development
     # Runs only when spec:approved is added
     if: github.event.label.name == 'spec:approved'
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
       contents: read
-    env:
-      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
-      - name: Update Labels
-        if: ${{ env.PROJECT_TOKEN != '' && !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
+      - name: Swap labels — stage:approval → stage:development
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.PROJECT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
-            
+
             try {
               await github.rest.issues.removeLabel({
                 owner,
@@ -38,59 +34,24 @@ jobs:
             } catch (error) {
               console.log('Label stage:approval not found or could not be removed');
             }
-            
+
             await github.rest.issues.addLabels({
               owner,
               repo,
               issue_number,
-              labels: ['stage:development', '{{IMPLEMENTATION_AGENT_LABEL}}', 'agent:working']
-            });
-
-      - name: Comment on issue to trigger agent and prevent race conditions
-        if: ${{ !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issueNumber = context.payload.issue.number;
-            const issueTitle = context.payload.issue.title;
-
-            const body = [
-              `🤖 **Agentic PDLC Orchestrator:** I have dispatched the implementation agent. Please wait for the Pull Request and avoid making concurrent commits on this task to prevent race conditions.`,
-              '',
-              `{{AGENT_HANDLE}} The spec for this issue has been approved. Please implement it exactly as described in the body above.`,
-              '',
-              '**Mandatory steps before you begin:**',
-              '1. `git fetch origin && git checkout main && git pull` — always start from the current HEAD',
-              '2. Read `AGENTS.md` — mandatory rules for agents in this repository',
-              '3. Read `docs/pdlc.md` — Definition of Done and invariants reference',
-              '',
-              '**Rules:**',
-              '- Implement strictly what the Acceptance Criteria describes',
-              '- Run `{{TEST_COMMAND}}` before opening the Pull Request',
-              `- Include \`Closes #${issueNumber}\` in the PR body`,
-              '- Create a descriptive branch branching from `main`',
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body,
+              labels: ['stage:development', 'agent:working']
             });
 
   trigger-agent-on-violation:
-    name: Trigger {{IMPLEMENTATION_AGENT_NAME}} for architecture violation
+    name: Flag architecture violation
     # Runs when architecture-violation is added (Sentinel flow)
     if: github.event.label.name == 'architecture-violation'
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
       contents: read
     steps:
-      - name: Comment on issue to trigger agent
-        if: ${{ !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
+      - name: Comment on issue
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +59,7 @@ jobs:
             const issueNumber = context.payload.issue.number;
 
             const body = [
-              `{{AGENT_HANDLE}} Please fix the architecture violation described in this issue.`,
+              `⚠️ **Architecture violation detected.** Please fix the issue described above.`,
               '',
               '**Mandatory steps before you begin:**',
               '1. `git fetch origin && git checkout main && git pull` — always start from the current HEAD',
@@ -106,7 +67,6 @@ jobs:
               '',
               '**Rules:**',
               '- Fix only what the violation points out — do not refactor unrelated code',
-              '- Run `{{TEST_COMMAND}}` before opening the Pull Request',
               `- Include \`Closes #${issueNumber}\` in the PR body`,
             ].join('\n');
 

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -18,14 +18,13 @@ jobs:
       contents: read
     steps:
       - name: Update Labels
-        if: ${{ !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
-            
+
             try {
               await github.rest.issues.removeLabel({
                 owner,
@@ -36,12 +35,16 @@ jobs:
             } catch (error) {
               console.log('Label stage:approval not found or could not be removed');
             }
-            
+
+            const agentLabel = '{{IMPLEMENTATION_AGENT_LABEL}}';
+            const labelsToAdd = ['stage:development', 'agent:working'];
+            if (!agentLabel.includes('{{')) labelsToAdd.push(agentLabel);
+
             await github.rest.issues.addLabels({
               owner,
               repo,
               issue_number,
-              labels: ['stage:development', '{{IMPLEMENTATION_AGENT_LABEL}}', 'agent:working']
+              labels: labelsToAdd
             });
 
       - name: Comment on issue to trigger agent and prevent race conditions

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -37,8 +37,8 @@ jobs:
             }
 
             const agentLabel = '{{IMPLEMENTATION_AGENT_LABEL}}';
-            const labelsToAdd = ['stage:development', 'agent:working'];
-            if (!agentLabel.includes('{{')) labelsToAdd.push(agentLabel);
+            const labelsToAdd = ['stage:development'];
+            if (!agentLabel.includes('{{')) labelsToAdd.push(agentLabel, 'agent:working');
 
             await github.rest.issues.addLabels({
               owner,


### PR DESCRIPTION
## Summary

- Adds 3-layer PDLC stage gate: CLAUDE.md soft rule + PreToolUse hook + CI hard gate
- Blocks `gh pr create` unless linked issue has `stage:approval` (or branch is `hotfix/`)
- Fixes `agent-trigger.yml`: label swap `stage:approval → stage:development` now runs unconditionally — works for repos without external agents (Jules)
- Template fix: separates label swap (always) from agent trigger comment (only when agent configured)

## Arquivos

| Arquivo | Mudança |
|---|---|
| `CLAUDE.md` | Soft rule: nunca criar PR sem stage:approval |
| `.agentic-pdlc/hooks/pdlc-stage-gate.sh` | Hook dogfood |
| `adapters/hooks/pdlc-stage-gate.sh` | Hook template |
| `.github/workflows/pdlc-stage-gate.yml` | CI hard gate dogfood |
| `templates/.github/workflows/pdlc-stage-gate.yml` | CI hard gate template |
| `.github/workflows/agent-trigger.yml` | Fix: sem guard de placeholder, sem PROJECT_TOKEN dep |
| `templates/.github/workflows/agent-trigger.yml` | Fix: label swap incondicional, agent label adicionado dinamicamente |
| `.agentic-pdlc/templates/.github/workflows/agent-trigger.yml` | Idem |
| `bin/cli.js` | Install hook via cli |
| `adapters/claude-code/skill.md` | Skill atualizada |
| `.claude/settings.json` | PreToolUse hook registrado |

## Test plan

- [ ] Tentar `gh pr create` em branch com issue sem `stage:approval` → bloqueado pelo hook
- [ ] Tentar `gh pr create` em branch `hotfix/` → passa sem bloqueio
- [ ] Adicionar `spec:approved` a issue com `stage:approval` → automation move para `stage:development` e `⚙️ Development`
- [ ] Verificar que template funciona em repos sem agente externo

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)