### PR TITLE
feat(pdlc): issue type inference with 85% confidence threshold

### DIFF
--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -94,14 +94,14 @@ This triggers the implementation agent via `agent-trigger.yml`.
 
 ## Shortcuts by Type
 
-The `type:*` label is the authoritative signal — set automatically by the agent via type inference. Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
+The `type:*` label is the authoritative signal — set automatically by the agent via type inference (see `adapters/claude-code/skill.md`). Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
 
 | Label | Flow |
 |---|---|
 | `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
 | `type:task` | Skips brainstorming — exploration → detailing → approval |
 | `type:bug` | Skips brainstorming — exploration → detailing → approval |
-| `type:spike` | Never reaches Development — exploration → detailing → conclusion comment |
+| `type:spike` | Skips brainstorming — exploration → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 

--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -77,6 +77,10 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | `spec:approved` | Issue | Green | Gate 2 — agent is cleared to implement |
 | `pr:in-review` | PR | Yellow | Awaiting code review |
 | `pr:approved` | PR | Green | Code review approved |
+| `type:us` | Issue | Blue | New feature or behavioral change — full flow |
+| `type:task` | Issue | Yellow | Operational/non-functional change — skips brainstorming |
+| `type:bug` | Issue | Red | Something broken — skips brainstorming |
+| `type:spike` | Issue | Gray | Research/evaluation — never reaches Development |
 
 ## Approval Gates
 
@@ -90,10 +94,16 @@ This triggers the implementation agent via `agent-trigger.yml`.
 
 ## Shortcuts by Type
 
-- **BUG** — Skips Brainstorming; enters Detail Solution with diagnostics + fix.
-- **TASK** — Skips Brainstorming; enters Detail Solution with operational steps.
-- **SPIKE** — Never reaches Development; delivery is a concluding comment.
-- **US** — Full flow observing both gates.
+The `type:*` label is the authoritative signal — set automatically by the agent via type inference. Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
+
+| Label | Flow |
+|---|---|
+| `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | Skips brainstorming — exploration → detailing → approval |
+| `type:bug` | Skips brainstorming — exploration → detailing → approval |
+| `type:spike` | Never reaches Development — exploration → detailing → conclusion comment |
+
+If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 
 ## Definition of Done
 

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -90,8 +90,10 @@ If `AGENTS.md` and `docs/pdlc.md` are present, you are in **Execution Mode**.
 
 **Run before anything else — before `stage:exploration`, before reading code.**
 
+Reading the issue title and body for type inference is exempt from the `stage:exploration` requirement: it is metadata already present in the request, not code reading or skill invocation.
+
 1. Check if issue already has a `type:*` label (`type:us`, `type:task`, `type:bug`, `type:spike`) → if yes, skip to Section 0.1.
-2. Read issue title + body.
+2. Read issue title + body (metadata only — no code reading at this step).
 3. Classify using these rules:
    - `type:task` — operational change, config, rename, docs update, non-functional (no user-facing behavior change)
    - `type:bug` — something broken that should work
@@ -107,7 +109,7 @@ If `AGENTS.md` and `docs/pdlc.md` are present, you are in **Execution Mode**.
 | `type:us` | Full flow: exploration → brainstorming → Gate 1 → detailing → approval |
 | `type:task` | Skip brainstorming: exploration → detailing → approval |
 | `type:bug` | Skip brainstorming: exploration → detailing → approval |
-| `type:spike` | exploration → detailing → conclusion comment (never reaches Development) |
+| `type:spike` | Skip brainstorming: exploration → detailing → conclusion comment (never reaches Development) |
 
 ### 0.1 Board Labels — Mandatory at Every State Transition
 

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -86,7 +86,30 @@ This detects which optional agents (Jules, QA Agent, Sentinel) are already confi
 
 If `AGENTS.md` and `docs/pdlc.md` are present, you are in **Execution Mode**. 
 
-### 0. Board Labels — Mandatory at Every State Transition
+### 0. [FIRST] Issue Type Identification
+
+**Run before anything else — before `stage:exploration`, before reading code.**
+
+1. Check if issue already has a `type:*` label (`type:us`, `type:task`, `type:bug`, `type:spike`) → if yes, skip to Section 0.1.
+2. Read issue title + body.
+3. Classify using these rules:
+   - `type:task` — operational change, config, rename, docs update, non-functional (no user-facing behavior change)
+   - `type:bug` — something broken that should work
+   - `type:spike` — research/evaluation spike, never reaches Development
+   - `type:us` — new feature, behavioral change, anything product-facing
+4. Confidence ≥ 85% → add inferred label: `gh issue edit <N> --add-label "type:<inferred>"`
+5. Confidence < 85% → default to `type:us`: `gh issue edit <N> --add-label "type:us"`
+
+**Type drives the PDLC flow:**
+
+| Type | Flow |
+|---|---|
+| `type:us` | Full flow: exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | Skip brainstorming: exploration → detailing → approval |
+| `type:bug` | Skip brainstorming: exploration → detailing → approval |
+| `type:spike` | exploration → detailing → conclusion comment (never reaches Development) |
+
+### 0.1 Board Labels — Mandatory at Every State Transition
 
 These label commands are non-negotiable. They run **before** the activity they announce — before reading code, before invoking any skill, before any other action.
 

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -96,7 +96,7 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 | `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
 | `type:task` | Skips brainstorming — exploration → detailing → approval |
 | `type:bug` | Skips brainstorming — exploration → detailing → approval |
-| `type:spike` | Never reaches Development — exploration → detailing → conclusion comment |
+| `type:spike` | Skips brainstorming — exploration → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -72,6 +72,10 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | `spec:approved` | Issue | Green | Gate 2 — agent is cleared to implement |
 | `pr:in-review` | PR | Yellow | Awaiting code review |
 | `pr:approved` | PR | Green | Code review approved |
+| `type:us` | Issue | Blue | New feature or behavioral change — full flow |
+| `type:task` | Issue | Yellow | Operational/non-functional change — skips brainstorming |
+| `type:bug` | Issue | Red | Something broken — skips brainstorming |
+| `type:spike` | Issue | Gray | Research/evaluation — never reaches Development |
 
 ## Approval Gates
 
@@ -85,10 +89,16 @@ This triggers the implementation agent via `agent-trigger.yml`.
 
 ## Shortcuts by Type
 
-- **BUG** — Skips Brainstorming; enters Detail Solution with diagnostics + fix.
-- **TASK** — Skips Brainstorming; enters Detail Solution with operational steps.
-- **SPIKE** — Never reaches Development; delivery is a concluding comment.
-- **US** — Full flow observing both gates.
+The `type:*` label is the authoritative signal — set automatically by the agent via type inference (see `adapters/claude-code/skill.md`). Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
+
+| Label | Flow |
+|---|---|
+| `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | Skips brainstorming — exploration → detailing → approval |
+| `type:bug` | Skips brainstorming — exploration → detailing → approval |
+| `type:spike` | Never reaches Development — exploration → detailing → conclusion comment |
+
+If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 
 ## Definition of Done
 

--- a/templates/docs/pdlc.md
+++ b/templates/docs/pdlc.md
@@ -97,14 +97,14 @@ This triggers the implementation agent via `agent-trigger.yml`.
 
 ## Shortcuts by Type
 
-The `type:*` label is the authoritative signal — set automatically by the agent via type inference. Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
+The `type:*` label is the authoritative signal — set automatically by the agent via type inference (see `adapters/claude-code/skill.md`). Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
 
 | Label | Flow |
 |---|---|
 | `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
 | `type:task` | Skips brainstorming — exploration → detailing → approval |
 | `type:bug` | Skips brainstorming — exploration → detailing → approval |
-| `type:spike` | Never reaches Development — exploration → detailing → conclusion comment |
+| `type:spike` | Skips brainstorming — exploration → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 

--- a/templates/docs/pdlc.md
+++ b/templates/docs/pdlc.md
@@ -80,6 +80,10 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | `qa:approved` | PR | Green | QA Agent passed — AC coverage verified |
 | `qa:needs-work` | PR | Red | QA Agent failed — PR needs changes |
 | `infra:qa-broken` | PR | Orange | QA Agent error — manual review required |
+| `type:us` | Issue | Blue | New feature or behavioral change — full flow |
+| `type:task` | Issue | Yellow | Operational/non-functional change — skips brainstorming |
+| `type:bug` | Issue | Red | Something broken — skips brainstorming |
+| `type:spike` | Issue | Gray | Research/evaluation — never reaches Development |
 
 ## Approval Gates
 
@@ -93,10 +97,16 @@ This triggers the implementation agent via `agent-trigger.yml`.
 
 ## Shortcuts by Type
 
-- **BUG** — Skips Brainstorming; enters Detail Solution with diagnostics + fix.
-- **TASK** — Skips Brainstorming; enters Detail Solution with operational steps.
-- **SPIKE** — Never reaches Development; delivery is a concluding comment.
-- **US** — Full flow observing both gates.
+The `type:*` label is the authoritative signal — set automatically by the agent via type inference. Title prefixes (`🔧 TASK:`, `👤 US:`) are hints for humans; the label drives the flow.
+
+| Label | Flow |
+|---|---|
+| `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | Skips brainstorming — exploration → detailing → approval |
+| `type:bug` | Skips brainstorming — exploration → detailing → approval |
+| `type:spike` | Never reaches Development — exploration → detailing → conclusion comment |
+
+If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary

- Agents infer `type:us/task/bug/spike` before starting work on any issue
- `type:task` and `type:bug` skip brainstorming stage (existing shortcuts now label-driven, not title-prefix-driven)
- Confidence < 85% → defaults to `type:us` (full flow — safe fallback)
- `type:*` labels created in repo
- `adapters/claude-code/skill.md`, `docs/pdlc.md` and both template copies updated

## Test plan

- [ ] Open issue #74 (clone of #67), ask agent to work on it — verify agent infers `type:task` and skips brainstorming
- [ ] Create a US issue without type label — verify agent infers `type:us` and runs full flow
- [ ] Manually add `type:bug` to an issue before asking agent to work — verify agent skips inference (label already present)

Closes #75

🤖 Generated with [Claude Code](https://claude.ai/code)