### PR TITLE
feat(board): rename 💡 Idea column to discourage manual moves

### DIFF
--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -4,7 +4,7 @@
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
-| 💡 Idea | Backlog — every new issue lands here | Manual |
+| 💡 Idea — don't move manually to Exploration | Backlog — tell agent: "work on issue #XX" | Don't move manually |
 | 🔍 Exploration | Claude is analyzing code and context | Label `stage:exploration` |
 | 🧠 Brainstorming | Claude proposed approaches, awaiting PM gate | Label `stage:brainstorming` |
 | 📐 Detail Solution | Claude is writing the technical spec | Label `stage:detailing` |

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -137,7 +137,7 @@ git checkout -b hotfix/<N>-<description>
 ```
 
 ### 1. Daily Upstream Loop
-Your job is to move issues from "💡 Idea" to "Detail Solution".
+Your job is to move issues from "💡 Idea - don't move manually to Exploration" to "📐 Detail Solution".
 When asked to work on a feature, you will:
 - Explore the code context.
 - Present architectural approaches (Brainstorming).

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -137,7 +137,7 @@ git checkout -b hotfix/<N>-<description>
 ```
 
 ### 1. Daily Upstream Loop
-Your job is to move issues from "Idea" to "Detail Solution".
+Your job is to move issues from "💡 Idea" to "Detail Solution".
 When asked to work on a feature, you will:
 - Explore the code context.
 - Present architectural approaches (Brainstorming).

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -4,7 +4,7 @@
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
-| 💡 Idea | Backlog — every new issue lands here | Manual |
+| 💡 Idea — don't move manually to Exploration | Backlog — tell agent: "work on issue #XX" | Don't move manually |
 | 🔍 Exploration | AI is analyzing code and context | Label `stage:exploration` |
 | 🧠 Brainstorming | AI proposed approaches and trade-offs | Label `stage:brainstorming` |
 | 📐 Detail Solution | AI is writing the technical spec | Label `stage:detailing` |

--- a/templates/docs/pdlc.md
+++ b/templates/docs/pdlc.md
@@ -4,7 +4,7 @@
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
-| 💡 Idea | Backlog — every new issue lands here | Manual |
+| 💡 Idea — don't move manually to Exploration | Backlog — tell agent: "work on issue #XX" | Don't move manually |
 | 🔍 Exploration | Claude is analyzing code and context | Label `stage:exploration` |
 | 🧠 Brainstorming | Claude proposed approaches, awaiting PM gate | Label `stage:brainstorming` |
 | 📐 Detail Solution | Claude is writing the technical spec | Label `stage:detailing` |


### PR DESCRIPTION
## Summary

- Board column renamed: `💡 Idea` → `💡 Idea - don't move manually to Exploration`
- Description updated: `Raw idea, not yet evaluated` → `Just tell your agent: work on issue #XX`
- 3 copies of `pdlc.md` (Board Columns table) updated
- `adapters/claude-code/skill.md` reference updated

## Test plan

- [ ] Board column shows new name and description in GitHub Projects UI
- [ ] Existing cards in the column are unaffected (option ID `bb6e5a20` preserved)

Closes #74

🤖 Generated with [Claude Code](https://claude.ai/code)