### PR TITLE
feat(board): activate Variant B — PR open → Testing, qa:approved → Code Review

### DIFF
--- a/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
@@ -37,12 +37,12 @@ jobs:
 
           for NUM in $ISSUE_NUMS; do
             LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved"; then
+            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development"; then
               echo "✅ Issue #$NUM approved"
             else
               STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
               echo "❌ Issue #$NUM missing approval (current: $STAGE)"
-              echo "   Required: stage:approval OR spec:approved label on the issue."
+              echo "   Required: stage:approval OR spec:approved OR stage:development label on the issue."
               echo "   Emergency bypass: add 'hotfix' label to this PR."
               exit 1
             fi

--- a/.agentic-pdlc/templates/.github/workflows/project-automation.yml
+++ b/.agentic-pdlc/templates/.github/workflows/project-automation.yml
@@ -2,7 +2,7 @@ name: PDLC Board Automation
 
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, labeled]
   pull_request_review:
     types: [submitted]
   issues:
@@ -115,16 +115,15 @@ jobs:
   #             });
   #           console.log(`Issue #${number} moved to Idea`);
 
-  # PR Opened → Move linked issue to Code Review / PR
-  # 💡 VARIANT B (QA Agent): If using an AI QA agent, change `STATUS_CODE_REVIEW_PR` to `STATUS_TESTING` on line ~158
+  # PR Opened → Move linked issue to Testing (Variant B — QA Agent enabled)
   move-card-on-pr-open:
-    name: Open PR → Code Review / PR
+    name: Open PR → Testing
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     env:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
-      - name: Move linked issue to Code Review / PR
+      - name: Move linked issue to Testing
         if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v7
         with:
@@ -153,10 +152,57 @@ jobs:
                   }
                 }`, {
                   p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
-                  v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR }
+                  v: { singleSelectOptionId: process.env.STATUS_TESTING }
                 });
             };
 
+            if (linkedIssues.length > 0) {
+              for (const n of linkedIssues) {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                await moveItem(issue.node_id);
+                console.log(`Issue #${n} → Testing`);
+              }
+            } else {
+              await moveItem(pr.node_id);
+              console.log(`PR #${prNumber} → Testing (no linked issue)`);
+            }
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:in-review'] }).catch(() => {});
+
+  # QA Approved → Move linked issue to Code Review / PR
+  move-card-on-qa-pass:
+    name: qa:approved → Code Review / PR
+    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'qa:approved'
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+    steps:
+      - name: Move linked issue to Code Review / PR
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const body = pr.body ?? '';
+            const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)].map(m => parseInt(m[1]));
+            const moveItem = async (nodeId) => {
+              const { addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($p: ID!, $c: ID!) {
+                  addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+                }`, { p: process.env.PROJECT_ID, c: nodeId });
+              await github.graphql(`
+                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                    projectV2Item { id }
+                  }
+                }`, {
+                  p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                  v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR }
+                });
+            };
             if (linkedIssues.length > 0) {
               for (const n of linkedIssues) {
                 const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
@@ -167,8 +213,6 @@ jobs:
               await moveItem(pr.node_id);
               console.log(`PR #${prNumber} → Code Review / PR (no linked issue)`);
             }
-
-            await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:in-review'] }).catch(() => {});
 
   # Review Approved → Add Label
   move-card-on-review-approved:

--- a/.agentic-pdlc/templates/.github/workflows/qa-agent.yml
+++ b/.agentic-pdlc/templates/.github/workflows/qa-agent.yml
@@ -13,6 +13,11 @@ jobs:
   qa:
     name: AC Coverage Verification (GitHub Models)
     runs-on: ubuntu-latest
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_ID: "{{PROJECT_ID}}"
+      STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
+      STATUS_CODE_REVIEW_PR: "{{ID_CODE_REVIEW_PR}}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,3 +82,47 @@ jobs:
             gh pr edit "$PR_NUMBER" --add-label "infra:qa-broken"
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** Could not parse GitHub Models response. Manual review required."
           fi
+
+      - name: Move board card to Code Review on qa:approved
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            if (!pr.labels.some(l => l.name === 'qa:approved')) {
+              console.log('qa:approved not on PR — skipping board move');
+              return;
+            }
+
+            const body = pr.body ?? '';
+            const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)]
+              .map(m => parseInt(m[1]));
+
+            const moveItem = async (nodeId) => {
+              const { addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($p: ID!, $c: ID!) {
+                  addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+                }`, { p: process.env.PROJECT_ID, c: nodeId });
+              await github.graphql(`
+                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                    projectV2Item { id }
+                  }
+                }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                     v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR } });
+            };
+
+            if (linkedIssues.length > 0) {
+              for (const n of linkedIssues) {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                await moveItem(issue.node_id);
+                console.log(`Issue #${n} → Code Review / PR`);
+              }
+            } else {
+              await moveItem(pr.node_id);
+              console.log(`PR #${prNumber} → Code Review / PR (no linked issue)`);
+            }

--- a/.github/workflows/pdlc-stage-gate.yml
+++ b/.github/workflows/pdlc-stage-gate.yml
@@ -37,12 +37,12 @@ jobs:
 
           for NUM in $ISSUE_NUMS; do
             LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved"; then
+            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development"; then
               echo "✅ Issue #$NUM approved"
             else
               STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
               echo "❌ Issue #$NUM missing approval (current: $STAGE)"
-              echo "   Required: stage:approval OR spec:approved label on the issue."
+              echo "   Required: stage:approval OR spec:approved OR stage:development label on the issue."
               echo "   Emergency bypass: add 'hotfix' label to this PR."
               exit 1
             fi

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -2,7 +2,7 @@ name: PDLC Board Automation
 
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, labeled]
   pull_request_review:
     types: [submitted]
   issues:
@@ -115,11 +115,64 @@ jobs:
   #             });
   #           console.log(`Issue #${number} moved to Idea`);
 
-  # PR Opened → Move linked issue to Code Review / PR
-  # 💡 VARIANT B (QA Agent): If using an AI QA agent, change `STATUS_CODE_REVIEW_PR` to `STATUS_TESTING` on line ~158
+  # PR Opened → Move linked issue to Testing (Variant B — QA Agent enabled)
   move-card-on-pr-open:
-    name: Open PR → Code Review / PR
+    name: Open PR → Testing
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    steps:
+      - name: Move linked issue to Testing
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const body = pr.body ?? '';
+
+            // Extract issues linked via "Closes #N", "Fixes #N", "Resolves #N"
+            const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)]
+              .map(m => parseInt(m[1]));
+
+            const moveItem = async (nodeId) => {
+              const { addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($p: ID!, $c: ID!) {
+                  addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+                }`, { p: process.env.PROJECT_ID, c: nodeId });
+
+              await github.graphql(`
+                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                    projectV2Item { id }
+                  }
+                }`, {
+                  p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                  v: { singleSelectOptionId: process.env.STATUS_TESTING }
+                });
+            };
+
+            if (linkedIssues.length > 0) {
+              for (const n of linkedIssues) {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                await moveItem(issue.node_id);
+                console.log(`Issue #${n} → Testing`);
+              }
+            } else {
+              await moveItem(pr.node_id);
+              console.log(`PR #${prNumber} → Testing (no linked issue)`);
+            }
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:in-review'] }).catch(() => {});
+
+  # QA Approved → Move linked issue to Code Review / PR
+  move-card-on-qa-pass:
+    name: qa:approved → Code Review / PR
+    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'qa:approved'
     runs-on: ubuntu-latest
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
@@ -136,7 +189,6 @@ jobs:
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const body = pr.body ?? '';
 
-            // Extract issues linked via "Closes #N", "Fixes #N", "Resolves #N"
             const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)]
               .map(m => parseInt(m[1]));
 
@@ -167,8 +219,6 @@ jobs:
               await moveItem(pr.node_id);
               console.log(`PR #${prNumber} → Code Review / PR (no linked issue)`);
             }
-
-            await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:in-review'] }).catch(() => {});
 
   # Review Approved → Add Label
   move-card-on-review-approved:

--- a/.github/workflows/qa-agent.yml
+++ b/.github/workflows/qa-agent.yml
@@ -13,6 +13,11 @@ jobs:
   qa:
     name: AC Coverage Verification (GitHub Models)
     runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
+      STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
+      STATUS_CODE_REVIEW_PR: "86ca9720"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,3 +82,47 @@ jobs:
             gh pr edit "$PR_NUMBER" --add-label "infra:qa-broken"
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** Could not parse GitHub Models response. Manual review required."
           fi
+
+      - name: Move board card to Code Review on qa:approved
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            if (!pr.labels.some(l => l.name === 'qa:approved')) {
+              console.log('qa:approved not on PR — skipping board move');
+              return;
+            }
+
+            const body = pr.body ?? '';
+            const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)]
+              .map(m => parseInt(m[1]));
+
+            const moveItem = async (nodeId) => {
+              const { addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($p: ID!, $c: ID!) {
+                  addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+                }`, { p: process.env.PROJECT_ID, c: nodeId });
+              await github.graphql(`
+                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                    projectV2Item { id }
+                  }
+                }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                     v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR } });
+            };
+
+            if (linkedIssues.length > 0) {
+              for (const n of linkedIssues) {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                await moveItem(issue.node_id);
+                console.log(`Issue #${n} → Code Review / PR`);
+              }
+            } else {
+              await moveItem(pr.node_id);
+              console.log(`PR #${prNumber} → Code Review / PR (no linked issue)`);
+            }

--- a/adapters/hooks/pdlc-stage-gate.sh
+++ b/adapters/hooks/pdlc-stage-gate.sh
@@ -31,9 +31,14 @@ if echo "$LABELS" | grep -qw "stage:approval"; then
   exit 0
 fi
 
+if echo "$LABELS" | grep -qw "stage:development"; then
+  echo "✅ PDLC: Issue #$ISSUE_NUM in development (spec already approved) — gate passed."
+  exit 0
+fi
+
 STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
 echo "❌ PDLC Stage Gate: Issue #$ISSUE_NUM is not approved."
 echo "   Current stage: $STAGE"
-echo "   Required: stage:approval label on the issue."
+echo "   Required: stage:approval or stage:development label on the issue."
 echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
 exit 1

--- a/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/templates/.github/workflows/pdlc-stage-gate.yml
@@ -37,12 +37,12 @@ jobs:
 
           for NUM in $ISSUE_NUMS; do
             LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved"; then
+            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development"; then
               echo "✅ Issue #$NUM approved"
             else
               STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
               echo "❌ Issue #$NUM missing approval (current: $STAGE)"
-              echo "   Required: stage:approval OR spec:approved label on the issue."
+              echo "   Required: stage:approval OR spec:approved OR stage:development label on the issue."
               echo "   Emergency bypass: add 'hotfix' label to this PR."
               exit 1
             fi

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -141,16 +141,15 @@ jobs:
   #             });
   #           console.log(`Issue #${number} moved to Idea`);
 
-  # PR Opened → Move linked issue to Code Review / PR
-  # 💡 VARIANT B (QA Agent): If using an AI QA agent, change `STATUS_CODE_REVIEW_PR` to `STATUS_TESTING` on line ~158
+  # PR Opened → Move linked issue to Testing (Variant B — QA Agent enabled)
   move-card-on-pr-open:
-    name: Open PR → Code Review / PR
+    name: Open PR → Testing
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     env:
       PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
     steps:
-      - name: Move linked issue to Code Review / PR
+      - name: Move linked issue to Testing
         if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v7
         with:
@@ -179,10 +178,57 @@ jobs:
                   }
                 }`, {
                   p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
-                  v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR }
+                  v: { singleSelectOptionId: process.env.STATUS_TESTING }
                 });
             };
 
+            if (linkedIssues.length > 0) {
+              for (const n of linkedIssues) {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
+                await moveItem(issue.node_id);
+                console.log(`Issue #${n} → Testing`);
+              }
+            } else {
+              await moveItem(pr.node_id);
+              console.log(`PR #${prNumber} → Testing (no linked issue)`);
+            }
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:in-review'] }).catch(() => {});
+
+  # QA Approved → Move linked issue to Code Review / PR
+  move-card-on-qa-pass:
+    name: qa:approved → Code Review / PR
+    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'qa:approved'
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+    steps:
+      - name: Move linked issue to Code Review / PR
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const body = pr.body ?? '';
+            const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)].map(m => parseInt(m[1]));
+            const moveItem = async (nodeId) => {
+              const { addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($p: ID!, $c: ID!) {
+                  addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+                }`, { p: process.env.PROJECT_ID, c: nodeId });
+              await github.graphql(`
+                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                    projectV2Item { id }
+                  }
+                }`, {
+                  p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                  v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR }
+                });
+            };
             if (linkedIssues.length > 0) {
               for (const n of linkedIssues) {
                 const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
@@ -193,8 +239,6 @@ jobs:
               await moveItem(pr.node_id);
               console.log(`PR #${prNumber} → Code Review / PR (no linked issue)`);
             }
-
-            await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:in-review'] }).catch(() => {});
 
   # Review Approved → Add Label
   move-card-on-review-approved:
@@ -214,52 +258,6 @@ jobs:
             const { owner, repo } = context.repo;
             try { await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: 'pr:in-review' }); } catch {}
             await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['pr:approved'] }).catch(() => {});
-
-  # OPTIONAL: Uncomment for Variant B (QA Agent enabled)
-  # When qa:approved is added to a PR, move linked issue to Code Review / PR
-  # move-card-on-qa-pass:
-  #   name: qa:approved → Code Review / PR
-  #   if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'qa:approved'
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
-  #   steps:
-  #     - name: Move linked issue to Code Review / PR
-  #       if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
-  #       uses: actions/github-script@v7
-  #       with:
-  #         github-token: ${{ env.PROJECT_PAT }}
-  #         script: |
-  #           const prNumber = context.payload.pull_request.number;
-  #           const { owner, repo } = context.repo;
-  #           const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
-  #           const body = pr.body ?? '';
-  #           const linkedIssues = [...body.matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)].map(m => parseInt(m[1]));
-  #           const moveItem = async (nodeId) => {
-  #             const { addProjectV2ItemById: { item } } = await github.graphql(`
-  #               mutation($p: ID!, $c: ID!) {
-  #                 addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
-  #               }`, { p: process.env.PROJECT_ID, c: nodeId });
-  #             await github.graphql(`
-  #               mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
-  #                 updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
-  #                   projectV2Item { id }
-  #                 }
-  #               }`, {
-  #                 p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
-  #                 v: { singleSelectOptionId: process.env.STATUS_CODE_REVIEW_PR }
-  #               });
-  #           };
-  #           if (linkedIssues.length > 0) {
-  #             for (const n of linkedIssues) {
-  #               const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
-  #               await moveItem(issue.node_id);
-  #               console.log(`Issue #${n} → Code Review / PR`);
-  #             }
-  #           } else {
-  #             await moveItem(pr.node_id);
-  #             console.log(`PR #${prNumber} → Code Review / PR (no linked issue)`);
-  #           }
 
   # PR Merged → Production
   move-card-on-pr-merge:


### PR DESCRIPTION
## Summary

- `move-card-on-pr-open` now moves linked issue to `🧪 Testing` instead of Code Review directly
- New `move-card-on-qa-pass` job: `qa:approved` label on PR → linked issue moves to `👁 Code Review / PR`
- Added `labeled` to `pull_request` trigger types (required for `qa:approved` event)
- Fixed `pdlc-stage-gate.sh` to also accept `stage:development` as a valid gate state (issue has this label after `agent-trigger.yml` swaps from `stage:approval`)
- All 3 copies updated: dogfood + `templates/` + `.agentic-pdlc/templates/`

## Test plan

- [ ] Open a PR linked to an issue → issue card moves to Testing
- [ ] QA Agent adds `qa:approved` → issue card moves to Code Review / PR
- [ ] `qa:needs-work` on PR → card stays in Testing (no move)
- [ ] Stage gate: branch `feat/78-*` with issue at `stage:development` → PR creation allowed

Closes #78

🤖 Generated with [Claude Code](https://claude.ai/code)