### PR TITLE
fix(board): inline board move to Development in agent-trigger.yml

### DIFF
--- a/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
@@ -16,6 +16,11 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_ID: "{{PROJECT_ID}}"
+      STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
+      STATUS_DEVELOPMENT: "{{ID_DEVELOPMENT}}"
     steps:
       - name: Update Labels
         uses: actions/github-script@v7
@@ -46,6 +51,27 @@ jobs:
               issue_number,
               labels: labelsToAdd
             });
+
+      - name: Move board card to Development
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const nodeId = context.payload.issue.node_id;
+            const number = context.payload.issue.number;
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: nodeId });
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                   v: { singleSelectOptionId: process.env.STATUS_DEVELOPMENT } });
+            console.log(`Issue #${number} → Development`);
 
       - name: Comment on issue to trigger agent and prevent race conditions
         if: ${{ !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}

--- a/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agent-trigger.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Move board card to Development
         if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{ env.PROJECT_PAT }}

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -15,6 +15,11 @@ jobs:
     permissions:
       issues: write
       contents: read
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
+      STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
+      STATUS_DEVELOPMENT: "2c9e78e6"
     steps:
       - name: Swap labels — stage:approval → stage:development
         uses: actions/github-script@v7
@@ -41,6 +46,27 @@ jobs:
               issue_number,
               labels: ['stage:development', 'agent:working']
             });
+
+      - name: Move board card to Development
+        if: ${{ env.PROJECT_TOKEN != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const nodeId = context.payload.issue.node_id;
+            const number = context.payload.issue.number;
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: nodeId });
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                   v: { singleSelectOptionId: process.env.STATUS_DEVELOPMENT } });
+            console.log(`Issue #${number} → Development`);
 
   trigger-agent-on-violation:
     name: Flag architecture violation

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Move board card to Development
         if: ${{ env.PROJECT_TOKEN != '' }}
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{ env.PROJECT_TOKEN }}

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -16,6 +16,11 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_ID: "{{PROJECT_ID}}"
+      STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
+      STATUS_DEVELOPMENT: "{{ID_DEVELOPMENT}}"
     steps:
       - name: Update Labels
         uses: actions/github-script@v7
@@ -46,6 +51,27 @@ jobs:
               issue_number,
               labels: labelsToAdd
             });
+
+      - name: Move board card to Development
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const nodeId = context.payload.issue.node_id;
+            const number = context.payload.issue.number;
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: nodeId });
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                   v: { singleSelectOptionId: process.env.STATUS_DEVELOPMENT } });
+            console.log(`Issue #${number} → Development`);
 
       - name: Comment on issue to trigger agent and prevent race conditions
         if: ${{ !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Move board card to Development
         if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{ env.PROJECT_PAT }}


### PR DESCRIPTION
## Summary

Root cause: `agent-trigger.yml` uses `GITHUB_TOKEN` to add `stage:development`. GitHub blocks `GITHUB_TOKEN`-triggered events from triggering other workflows — so `project-automation.yml` never ran for the label addition and the card skipped Development entirely (Approval → Code Review directly).

Fix: add inline GraphQL board move step in `agent-trigger.yml` using `PROJECT_TOKEN` immediately after the label swap. No event chain dependency.

- `.github/workflows/agent-trigger.yml`: new `Move board card to Development` step
- `templates/.github/workflows/agent-trigger.yml`: same with `{{PROJECT_ID}}`/`{{STATUS_FIELD_ID}}`/`{{ID_DEVELOPMENT}}` placeholders
- `.agentic-pdlc/templates/.github/workflows/agent-trigger.yml`: same

## Test plan

- [ ] Add `spec:approved` to an issue → card moves to ⚙️ Development immediately
- [ ] `PROJECT_TOKEN` not set → step skipped via `if:` guard, no failure

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/code)