### PR TITLE
feat(board): auto-add new issues to project board on creation

### DIFF
--- a/.agentic-pdlc/templates/.github/workflows/add-to-board.yml
+++ b/.agentic-pdlc/templates/.github/workflows/add-to-board.yml
@@ -1,0 +1,38 @@
+name: Add to Board on Open
+
+on:
+  issues:
+    types: [opened]
+
+env:
+  PROJECT_ID: "{{PROJECT_ID}}"
+  STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
+  STATUS_IDEA: "{{ID_IDEA}}"
+
+jobs:
+  add-to-board:
+    name: Auto-add new issue to board
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+    steps:
+      - name: Add issue to project board
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const nodeId = context.payload.issue.node_id;
+            const number = context.payload.issue.number;
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: nodeId });
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                   v: { singleSelectOptionId: process.env.STATUS_IDEA } });
+            console.log(`Issue #${number} added to board → Idea`);

--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -1,0 +1,38 @@
+name: Add to Board on Open
+
+on:
+  issues:
+    types: [opened]
+
+env:
+  PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
+  STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
+  STATUS_IDEA: "bb6e5a20"
+
+jobs:
+  add-to-board:
+    name: Auto-add new issue to board
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    steps:
+      - name: Add issue to project board
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const nodeId = context.payload.issue.node_id;
+            const number = context.payload.issue.number;
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: nodeId });
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                   v: { singleSelectOptionId: process.env.STATUS_IDEA } });
+            console.log(`Issue #${number} added to board → Idea`);

--- a/templates/.github/workflows/add-to-board.yml
+++ b/templates/.github/workflows/add-to-board.yml
@@ -1,0 +1,38 @@
+name: Add to Board on Open
+
+on:
+  issues:
+    types: [opened]
+
+env:
+  PROJECT_ID: "{{PROJECT_ID}}"
+  STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
+  STATUS_IDEA: "{{ID_IDEA}}"
+
+jobs:
+  add-to-board:
+    name: Auto-add new issue to board
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+    steps:
+      - name: Add issue to project board
+        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.PROJECT_PAT }}
+          script: |
+            const nodeId = context.payload.issue.node_id;
+            const number = context.payload.issue.number;
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: nodeId });
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, { p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                   v: { singleSelectOptionId: process.env.STATUS_IDEA } });
+            console.log(`Issue #${number} added to board → Idea`);


### PR DESCRIPTION
## Summary

New workflow `.github/workflows/add-to-board.yml` fires on `issues: opened` and adds the new issue to the project board with status `💡 Idea`. Idempotent — `addProjectV2ItemById` returns existing item silently if issue already on board.

- `.github/workflows/add-to-board.yml`: new workflow (dogfood)
- `templates/.github/workflows/add-to-board.yml`: template with `{{PROJECT_ID}}`/`{{STATUS_FIELD_ID}}`/`{{ID_IDEA}}` placeholders
- `.agentic-pdlc/templates/.github/workflows/add-to-board.yml`: same

## Test plan

- [ ] Create new issue → appears in project board under `💡 Idea`
- [ ] `PROJECT_TOKEN` not set → step skipped via `if:` guard, no failure

Closes #76

🤖 Generated with [Claude Code](https://claude.ai/code)