### PR TITLE
fix(onboarding): fluent setup flow with auto PROJECT_PAT provisioning

### DIFF
--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -25,7 +25,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
 1. **Language Detection:** Analyze the user's previous prompts and preferred language. Conduct this entire Setup Mode and ask all your interactive questions in that same language.
 2. Acknowledge that the framework is not yet set up.
 3. **Pre-filled Context:** Before asking any questions, read the following files if they exist:
-   - `.agentic-pdlc/cli-context.json` — written by the CLI. Contains `projectName`, `repoOwner`, `repoName`. Use these values directly and skip the corresponding questions.
+   - `.agentic-pdlc/cli-context.json` — written by the CLI. Contains `projectName`, `repoOwner`, `repoName`, `projectNumber`, `isOrg`, `boardUrl`, and `patAutoSet` (boolean). Use these values directly and skip the corresponding questions. Honor `patAutoSet` in Step 7 and `boardUrl` in Step 10.
    - `.agentic-pdlc/templates/docs/pdlc.md` — the CLI pre-fills PROJECT_ID, STATUS_FIELD_ID, REPO_OWNER, REPO_NAME, and all 9 column option IDs. If none of the values still contain `{{...}}` placeholders, skip the entire Board IDs question group.
    - `.agentic-pdlc/templates/.github/workflows/project-automation.yml` — the CLI also pre-fills all ID placeholders here. When writing the workflow file, the remaining `{{...}}` placeholders are only non-ID ones (project name, commands, etc.).
 4. Interactively ask the user only for the **missing values**, **one group at a time**:
@@ -50,28 +50,33 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
      - c) **Other** — *Enter the agent's handle.*
 5. Generate and write the missing files replacing the `{{SCREAMING_SNAKE_CASE}}` placeholders using the templates in `.agentic-pdlc/templates/`.
 6. Offer to run the `gh` commands for labels (`spec:approved`, `pr:in-review`, `pr:approved`, `architecture-violation`).
-7. **Set up the `PROJECT_PAT` secret (required for board automation):**
-   > ⚠️ This is **different** from the `gh auth` OAuth token used for the CLI setup. That token lets you run `gh` commands locally. This PAT is for GitHub Actions workflows that move cards on the board automatically — `GITHUB_TOKEN` in CI/CD does not have `project` scope by default.
+7. **`PROJECT_PAT` secret (required for board automation):**
 
-   Without `PROJECT_PAT`, all board card movements in CI will silently skip — no error, no cards moving.
+   Read `patAutoSet` from `.agentic-pdlc/cli-context.json`:
 
-   Steps:
-   1. Go to: **github.com/settings/tokens** → *Generate new token (classic)*
-   2. Name: `PROJECT_PAT — <repo-name>`
-   3. Select scopes: ✅ `repo` + ✅ `project`
-   4. Copy the token, then run:
-      ```
-      gh secret set PROJECT_PAT --body "<your-token>"
-      ```
-   5. Reply **"secret set"** (or "done") when finished so setup can continue.
+   **If `patAutoSet === true`:** The CLI already configured this secret automatically. Print `✅ PROJECT_PAT is configured.` and continue to Step 8 — do not ask the user anything.
+
+   **If `patAutoSet === false` (org repo):** Show the block below and wait for the user to reply "done" or "secret set" before continuing:
+
+   > Your repo is in an organization. For security, `PROJECT_PAT` must be a dedicated PAT (not your personal OAuth token). Without it, all board card movements in CI will silently skip — no error surfaced.
+   >
+   > 1. Open: **github.com/settings/tokens** → *Generate new token (classic)*
+   > 2. Name: `PROJECT_PAT — <repo-name>`
+   > 3. Select scopes: ✅ `repo` + ✅ `project`
+   > 4. Copy the token, then run:
+   >    ```
+   >    gh secret set PROJECT_PAT --body "<your-token>" --repo <owner>/<repo>
+   >    ```
+   > 5. Reply **"done"** when finished.
 8. **IMPORTANT:** Delete the setup prompt file by running exactly:
    ```
    rm -f .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md
    ```
    **Do NOT run `git add` or any other git command.** These files were never committed and do not exist in the git index. This command must run **before** the commit step.
 9. Commit everything with the message: `chore: setup agentic-pdlc framework`.
-10. Conclude Setup Mode. Read `projectNumber` from `.agentic-pdlc/cli-context.json` and show the user their board URL:
-    `https://github.com/users/{repoOwner}/projects/{projectNumber}/views/1?layout=board`
+10. Conclude Setup Mode. Read `boardUrl` from `.agentic-pdlc/cli-context.json` and show the user exactly this (do not reconstruct the URL — `boardUrl` already includes the correct `users/` or `orgs/` path segment and `?layout=board`):
+
+    `🎉 Setup complete! Your board: <boardUrl>`
 
 ---
 

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -51,14 +51,19 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
 5. Generate and write the missing files replacing the `{{SCREAMING_SNAKE_CASE}}` placeholders using the templates in `.agentic-pdlc/templates/`.
 6. Offer to run the `gh` commands for labels (`spec:approved`, `pr:in-review`, `pr:approved`, `architecture-violation`).
 7. **Set up the `PROJECT_PAT` secret (required for board automation):**
-   The board automation workflows need a GitHub Personal Access Token (classic) with `project` scope. Without it, all board card movements will silently skip — no error, no cards moving.
-   - Go to: **github.com/settings/tokens** → *Generate new token (classic)*
-   - Select scopes: ✅ `repo` + ✅ `project`
-   - Copy the token, then run:
-     ```
-     gh secret set PROJECT_PAT --body "<your-token>"
-     ```
-   Wait for the user to confirm the secret is set before continuing.
+   > ⚠️ This is **different** from the `gh auth` OAuth token used for the CLI setup. That token lets you run `gh` commands locally. This PAT is for GitHub Actions workflows that move cards on the board automatically — `GITHUB_TOKEN` in CI/CD does not have `project` scope by default.
+
+   Without `PROJECT_PAT`, all board card movements in CI will silently skip — no error, no cards moving.
+
+   Steps:
+   1. Go to: **github.com/settings/tokens** → *Generate new token (classic)*
+   2. Name: `PROJECT_PAT — <repo-name>`
+   3. Select scopes: ✅ `repo` + ✅ `project`
+   4. Copy the token, then run:
+      ```
+      gh secret set PROJECT_PAT --body "<your-token>"
+      ```
+   5. Reply **"secret set"** (or "done") when finished so setup can continue.
 8. **IMPORTANT:** Delete the setup prompt file by running exactly:
    ```
    rm -f .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -121,6 +121,43 @@ async function runSetup() {
     process.exit(1);
   }
 
+  function getScopes() {
+    try {
+      const out = execFileSync('gh', ['api', 'user', '-i'], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+      const line = out.split('\n').find(l => l.toLowerCase().startsWith('x-oauth-scopes:'));
+      return line ? line.split(':').slice(1).join(':').split(',').map(s => s.trim()) : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  const scopesBefore = getScopes();
+  if (scopesBefore.length > 0 && !scopesBefore.includes('project')) {
+    console.log(`${yellow}⚠️  Token missing 'project' scope — required for GitHub Projects board.${reset}`);
+    console.log(`${yellow}   Refreshing token now (browser may open)...${reset}\n`);
+    try {
+      execSync('gh auth refresh -h github.com -s project', { stdio: 'inherit' });
+    } catch (e) {
+      console.log(`${red}❌ Token refresh failed. Run manually: gh auth refresh -h github.com -s project${reset}`);
+      rl.close();
+      process.exit(1);
+    }
+    const scopesAfter = getScopes();
+    if (scopesAfter.length > 0 && !scopesAfter.includes('project')) {
+      console.log(`\n${red}❌ 'project' scope still missing after refresh.${reset}`);
+      console.log(`${yellow}   Active scopes: ${scopesAfter.join(', ')}${reset}`);
+      console.log(`${yellow}   Note: gh uses OAuth tokens — visible at github.com/settings/applications, not /settings/tokens${reset}`);
+      console.log(`${yellow}   Try manually: gh auth refresh -h github.com -s project${reset}`);
+      rl.close();
+      process.exit(1);
+    }
+    if (scopesAfter.length > 0) {
+      console.log(`\n${green}✅ Token refreshed. Active scopes: ${scopesAfter.join(', ')}${reset}\n`);
+    } else {
+      console.log(`\n${green}✅ Token refreshed with 'project' scope.${reset}\n`);
+    }
+  }
+
   const agentAnswer = await askQuestion(i18n.ask_agent);
   const agent = agentAnswer.trim().toLowerCase();
   if (!['claude', 'cursor', 'copilot'].includes(agent)) {
@@ -190,14 +227,14 @@ async function runSetup() {
   let ownerId, projectId, projectNumber;
   try {
     if (isOrg) {
-      const orgOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=query($login: String!) { organization(login: $login) { id } }', '-f', `login=${repoOwner}`, '--jq', '.data.organization.id']).toString().trim();
+      const orgOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query=query($login: String!) { organization(login: $login) { id } }', '-f', `login=${repoOwner}`, '--jq', '.data.organization.id'], { stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
       ownerId = orgOutput;
     } else {
-      const userOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query={ viewer { id } }', '--jq', '.data.viewer.id']).toString().trim();
+      const userOutput = execFileSync('gh', ['api', 'graphql', '-f', 'query={ viewer { id } }', '--jq', '.data.viewer.id'], { stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
       ownerId = userOutput;
     }
 
-    const projectCreateRaw = execFileSync('gh', ['api', 'graphql', '-f', 'query=mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id number } } }', '-f', `owner=${ownerId}`, '-f', `title=${boardName}`]).toString().trim();
+    const projectCreateRaw = execFileSync('gh', ['api', 'graphql', '-f', 'query=mutation($owner: ID!, $title: String!) { createProjectV2(input: {ownerId: $owner, title: $title}) { projectV2 { id number } } }', '-f', `owner=${ownerId}`, '-f', `title=${boardName}`], { stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
     const projectCreateResponse = JSON.parse(projectCreateRaw);
     if (projectCreateResponse.errors) {
       throw new Error(projectCreateResponse.errors.map(e => e.message).join('; '));
@@ -217,7 +254,14 @@ async function runSetup() {
     }
 
   } catch (err) {
-    console.log(`  ${i18n.project_err}${err.message}`);
+    const isScopeError = (err.message || '').includes("required scopes") || (err.stderr || '').toString().includes("required scopes");
+    if (isScopeError) {
+      console.log(`  ${red}❌ Token missing 'project' scope.${reset}`);
+      console.log(`  ${yellow}Fix: gh auth refresh -s project${reset}`);
+      console.log(`  ${yellow}Then re-run: npx create-agentic-pdlc${reset}`);
+    } else {
+      console.log(`  ${i18n.project_err}${err.message}`);
+    }
   }
 
   let statusFieldId;
@@ -311,7 +355,11 @@ async function runSetup() {
       }
 
       fs.writeFileSync(pdlcDest, pdlcContent);
-      console.log(`${i18n.pdlc_prefilled}`);
+      if (projectId && statusFieldId && Object.keys(optionMap).length > 0) {
+        console.log(`${i18n.pdlc_prefilled}`);
+      } else {
+        console.log(`${yellow}⚠️  pdlc.md copied — Project IDs not filled (board creation failed). Re-run after fixing token.${reset}`);
+      }
     }
 
     // Pre-fill project-automation.yml with the same IDs so the agent doesn't need to map them

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -84,6 +84,11 @@ console.log(`${cyan}============================================================
 console.log(`${cyan}${i18n.welcome}${reset}`);
 console.log(`${cyan}================================================================${reset}\n`);
 
+function buildBoardUrl(repoOwner, projectNumber, isOrg) {
+  const segment = isOrg ? 'orgs' : 'users';
+  return `https://github.com/${segment}/${repoOwner}/projects/${projectNumber}/views/1?layout=board`;
+}
+
 // Helper function to recursively copy directories
 function copyDirSync(src, dest) {
   if (!fs.existsSync(dest)) fs.mkdirSync(dest, { recursive: true });
@@ -322,6 +327,23 @@ async function runSetup() {
     }
   }
 
+  // Auto-provision PROJECT_PAT for personal repos
+  let patAutoSet = false;
+  if (projectId && !isOrg) {
+    try {
+      const tokenOut = execFileSync('gh', ['auth', 'token'], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' }).trim();
+      if (tokenOut) {
+        execFileSync('gh', ['secret', 'set', 'PROJECT_PAT', '--body', tokenOut, '--repo', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
+        patAutoSet = true;
+        console.log(`\n${green}✅ PROJECT_PAT secret set automatically (uses your gh OAuth token).${reset}`);
+      }
+    } catch (err) {
+      console.log(`\n${yellow}⚠️  Could not auto-set PROJECT_PAT. Agent will guide manual setup.${reset}`);
+    }
+  } else if (projectId && isOrg) {
+    console.log(`\n${yellow}ℹ️  Org repo detected — PROJECT_PAT will require manual setup for security.${reset}`);
+  }
+
   console.log(`\n${yellow}${i18n.scaffolding}${reset}`);
 
   // We copy the templates folder so the agent has the real text logic to replace and rename
@@ -386,7 +408,16 @@ async function runSetup() {
   // Write CLI context for the agent to consume in Setup Mode
   try {
     const cliContextPath = path.join(targetDir, '.agentic-pdlc', 'cli-context.json');
-    fs.writeFileSync(cliContextPath, JSON.stringify({ projectName, repoOwner, repoName, projectNumber }, null, 2));
+    const boardUrl = projectNumber ? buildBoardUrl(repoOwner, projectNumber, isOrg) : null;
+    fs.writeFileSync(cliContextPath, JSON.stringify({
+      projectName,
+      repoOwner,
+      repoName,
+      projectNumber,
+      isOrg,
+      boardUrl,
+      patAutoSet
+    }, null, 2));
   } catch (err) {
     // Non-fatal — agent will ask for the values instead
   }


### PR DESCRIPTION
## Summary

- Auto-refresh `project` OAuth scope at CLI startup (before any user questions) — eliminating the most common new-user failure
- Auto-provision `PROJECT_PAT` repo secret for personal repos using `gh auth token` — zero manual steps
- Org repos defer to polished manual instructions with explicit "reply done" prompt
- Write `boardUrl` (with `?layout=board`, correct `users/` vs `orgs/` segment) and `patAutoSet` flag to `cli-context.json`
- `skill.md` Step 7 reads `patAutoSet`: skips entirely for personal repos, shows targeted org instructions otherwise
- `skill.md` Step 10 reads `boardUrl` directly from context instead of reconstructing the URL

## Why `permissions: projects: write` was ruled out

GitHub Actions `GITHUB_TOKEN` has no `projects` permission key — only the deprecated `repository-projects` (Classic Projects). ProjectsV2 GraphQL mutations require a token with `project` scope. PAT remains the only viable approach (confirmed via GitHub docs + community discussion #46681).

## Test plan

- [ ] Personal repo, token already has `project` scope → no browser prompt, `PROJECT_PAT` auto-set, board URL shown with `?layout=board`
- [ ] Personal repo, token missing `project` scope → browser opens inline, token refreshed, `PROJECT_PAT` auto-set, setup continues without re-run
- [ ] Org repo → manual PAT instructions shown, explicit "reply done" prompt, no ambiguous wait message
- [ ] Card moves automatically on board when agent picks up first issue

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)