### PR TITLE
feat(pdlc): enforce full cycle for all issue types, add bypass mechanism

### DIFF
--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -78,8 +78,8 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | `pr:in-review` | PR | Yellow | Awaiting code review |
 | `pr:approved` | PR | Green | Code review approved |
 | `type:us` | Issue | Blue | New feature or behavioral change — full flow |
-| `type:task` | Issue | Yellow | Operational/non-functional change — skips brainstorming |
-| `type:bug` | Issue | Red | Something broken — skips brainstorming |
+| `type:task` | Issue | Yellow | Operational/non-functional change — full flow |
+| `type:bug` | Issue | Red | Something broken — full flow |
 | `type:spike` | Issue | Gray | Research/evaluation — never reaches Development |
 
 ## Approval Gates
@@ -98,12 +98,23 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 
 | Label | Flow |
 |---|---|
-| `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | Skips brainstorming — exploration → detailing → approval |
-| `type:bug` | Skips brainstorming — exploration → detailing → approval |
-| `type:spike` | Skips brainstorming — exploration → detailing → conclusion comment (never reaches Development) |
+| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
+
+## Bypass Mechanism
+
+Agents MUST NOT skip any stage. The ONLY authorized bypasses are:
+
+| Mechanism | Who authorizes | What it bypasses |
+|---|---|---|
+| `human-approved` label on issue | PM (human) only | All stage gates |
+| Branch prefix `hotfix/` | PM (human) only | PR gate only |
+
+Agents MUST NOT self-authorize a bypass. Stop and ask the PM explicitly.
 
 ## Definition of Done
 

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -116,10 +116,10 @@ Reading the issue title and body for type inference is exempt from the `stage:ex
 
 | Type | Flow |
 |---|---|
-| `type:us` | Full flow: exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | Skip brainstorming: exploration → detailing → approval |
-| `type:bug` | Skip brainstorming: exploration → detailing → approval |
-| `type:spike` | Skip brainstorming: exploration → detailing → conclusion comment (never reaches Development) |
+| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 ### 0.1 Board Labels — Mandatory at Every State Transition
 

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -73,8 +73,8 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | `pr:in-review` | PR | Yellow | Awaiting code review |
 | `pr:approved` | PR | Green | Code review approved |
 | `type:us` | Issue | Blue | New feature or behavioral change — full flow |
-| `type:task` | Issue | Yellow | Operational/non-functional change — skips brainstorming |
-| `type:bug` | Issue | Red | Something broken — skips brainstorming |
+| `type:task` | Issue | Yellow | Operational/non-functional change — full flow |
+| `type:bug` | Issue | Red | Something broken — full flow |
 | `type:spike` | Issue | Gray | Research/evaluation — never reaches Development |
 
 ## Approval Gates
@@ -93,12 +93,23 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 
 | Label | Flow |
 |---|---|
-| `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | Skips brainstorming — exploration → detailing → approval |
-| `type:bug` | Skips brainstorming — exploration → detailing → approval |
-| `type:spike` | Skips brainstorming — exploration → detailing → conclusion comment (never reaches Development) |
+| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
+
+## Bypass Mechanism
+
+Agents MUST NOT skip any stage. The ONLY authorized bypasses are:
+
+| Mechanism | Who authorizes | What it bypasses |
+|---|---|---|
+| `human-approved` label on issue | PM (human) only | All stage gates |
+| Branch prefix `hotfix/` | PM (human) only | PR gate only |
+
+Agents MUST NOT self-authorize a bypass. Stop and ask the PM explicitly.
 
 ## Definition of Done
 

--- a/templates/docs/pdlc.md
+++ b/templates/docs/pdlc.md
@@ -81,8 +81,8 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | `qa:needs-work` | PR | Red | QA Agent failed — PR needs changes |
 | `infra:qa-broken` | PR | Orange | QA Agent error — manual review required |
 | `type:us` | Issue | Blue | New feature or behavioral change — full flow |
-| `type:task` | Issue | Yellow | Operational/non-functional change — skips brainstorming |
-| `type:bug` | Issue | Red | Something broken — skips brainstorming |
+| `type:task` | Issue | Yellow | Operational/non-functional change — full flow |
+| `type:bug` | Issue | Red | Something broken — full flow |
 | `type:spike` | Issue | Gray | Research/evaluation — never reaches Development |
 
 ## Approval Gates
@@ -101,12 +101,23 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 
 | Label | Flow |
 |---|---|
-| `type:us` | Full flow — exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | Skips brainstorming — exploration → detailing → approval |
-| `type:bug` | Skips brainstorming — exploration → detailing → approval |
-| `type:spike` | Skips brainstorming — exploration → detailing → conclusion comment (never reaches Development) |
+| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
+
+## Bypass Mechanism
+
+Agents MUST NOT skip any stage. The ONLY authorized bypasses are:
+
+| Mechanism | Who authorizes | What it bypasses |
+|---|---|---|
+| `human-approved` label on issue | PM (human) only | All stage gates |
+| Branch prefix `hotfix/` | PM (human) only | PR gate only |
+
+Agents MUST NOT self-authorize a bypass. Stop and ask the PM explicitly.
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary
- All `type:bug` and `type:task` issues now require the full PDLC cycle — no more brainstorming skip
- `type:spike` also now goes through brainstorming (endpoint remains: never reaches Development)
- Added `## Bypass Mechanism` section to all 3 `pdlc.md` files documenting `human-approved` label and `hotfix/` as the only authorized bypasses
- Updated `adapters/claude-code/skill.md` type flow table
- Updated GitHub label descriptions for `type:bug` and `type:task`

## Test plan
- [ ] Verify no "skips brainstorming" text remains in any `.md` file
- [ ] Confirm `type:bug` label description updated on GitHub
- [ ] Confirm Bypass Mechanism section present in all 3 pdlc.md variants

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)