### PR TITLE
fix: move-card-on-pr-open now updates issue labels to stage:testing

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -156,11 +156,17 @@ jobs:
                 });
             };
 
+            const stageLabelsToRemove = ['stage:development', 'stage:brainstorming', 'stage:detailing', 'stage:approval', 'jules', 'agent:working'];
+
             if (linkedIssues.length > 0) {
               for (const n of linkedIssues) {
                 const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: n });
                 await moveItem(issue.node_id);
-                console.log(`Issue #${n} → Testing`);
+                for (const label of stageLabelsToRemove) {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name: label }).catch(() => {});
+                }
+                await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['stage:testing'] }).catch(() => {});
+                console.log(`Issue #${n} → Testing (labels updated)`);
               }
             } else {
               await moveItem(pr.node_id);


### PR DESCRIPTION
## Summary

- After `moveItem()` for each linked issue, removes `stage:development`, `stage:brainstorming`, `stage:detailing`, `stage:approval`, `jules`, `agent:working`
- Adds `stage:testing` to linked issue
- Board card and issue labels now stay in sync when PR is opened

Closes #97

## Test plan

- [ ] Open a PR with `Closes #N` where issue #N has `stage:development` label
- [ ] Verify issue #N loses all stage/agent labels and gains `stage:testing`
- [ ] Verify PR gets `pr:in-review` label (existing behavior unchanged)
- [ ] Verify board card moves to Testing column

🤖 **Agent:** Generated with [Claude Code](https://claude.com/claude-code)