### PR TITLE
fix(cli+automation): Idea column text, label cleanup on close, remove default GitHub labels

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [labeled]
+    types: [labeled, closed]
 
 env:
   PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
@@ -288,3 +288,25 @@ jobs:
             } else {
               await moveItem(pr.node_id);
             }
+
+  cleanup-labels-on-close:
+    name: Issue closed → strip stage/agent labels
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove transient labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const toRemove = [
+              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:approval', 'stage:development', 'stage:testing',
+              'agent:working', 'qa:needs-work', 'pr:in-review', 'jules'
+            ];
+            for (const label of toRemove) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label }).catch(() => {});
+            }
+            console.log(`Issue #${issue_number} labels cleaned up`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,15 @@ NEVER run `gh pr create` unless one of these is true:
 Advance stages first: `exploration` → `brainstorming` → `detailing` → `approval`
 
 The PreToolUse hook will block the action automatically if this rule is violated.
+
+## Human-in-the-Loop
+
+| Transition | Gate |
+|---|---|
+| → `stage:exploration` | Autonomous — apply immediately |
+| → `stage:brainstorming` | Ask user — present exploration findings, wait for ok |
+| → `stage:detailing` | Ask user — present brainstorming plan, wait for ok |
+| → `stage:approval` | **Autonomous** — agent completes spec end-to-end, advances without asking |
+| → `stage:development` | Human applies `spec:approved` label — that IS the gate |
+
+**Detailing is fully autonomous.** Write the complete spec, add it to the issue, advance to `stage:approval` — no confirmation needed.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -227,6 +227,16 @@ async function runSetup() {
     }
   }
 
+  const defaultLabels = [
+    'bug', 'documentation', 'duplicate', 'enhancement',
+    'good first issue', 'help wanted', 'invalid', 'question', 'wontfix'
+  ];
+  for (const label of defaultLabels) {
+    try {
+      execFileSync('gh', ['label', 'delete', label, '--repo', repo, '--yes'], { stdio: 'ignore' });
+    } catch (_) {}
+  }
+
   // Project V2
   console.log(`\n${cyan}${i18n.creating_project}${reset}`);
   let ownerId, projectId, projectNumber;
@@ -280,7 +290,7 @@ async function runSetup() {
 
       if (statusFieldId) {
         const columns = [
-          { name: "💡 Idea", description: "Backlog — every new issue lands here", color: "GRAY" },
+          { name: "💡 Idea - No move to Exploration directly", description: "Just tell your agent to work on issue #XX", color: "GRAY" },
           { name: "🔍 Exploration", description: "AI is analyzing code and context", color: "PURPLE" },
           { name: "🧠 Brainstorming", description: "AI proposed approaches and trade-offs", color: "PINK" },
           { name: "📐 Detail Solution", description: "AI is writing the technical spec", color: "BLUE" },

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [labeled, edited]
+    types: [labeled, edited, closed]
 
 env:
   PROJECT_ID: "{{PROJECT_ID}}"
@@ -302,3 +302,25 @@ jobs:
             } else {
               await moveItem(pr.node_id);
             }
+
+  cleanup-labels-on-close:
+    name: Issue closed → strip stage/agent labels
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove transient labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const toRemove = [
+              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:approval', 'stage:development', 'stage:testing',
+              'agent:working', 'qa:needs-work', 'pr:in-review', 'jules'
+            ];
+            for (const label of toRemove) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label }).catch(() => {});
+            }
+            console.log(`Issue #${issue_number} labels cleaned up`);


### PR DESCRIPTION
## Summary

- **#91**: Idea column renamed to `💡 Idea - No move to Exploration directly` with subtitle `Just tell your agent to work on issue #XX`
- **#92**: `issues: [closed]` trigger added + `cleanup-labels-on-close` job strips transient labels (`stage:*`, `agent:working`, `qa:needs-work`, `pr:in-review`, `jules`) when an issue is closed — keeps only approval labels
- **#93**: After creating PDLC labels, CLI now deletes the 9 default GitHub labels (`bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`)
- **docs**: CLAUDE.md updated with correct human-in-the-loop gate table

## Test plan

- [ ] Run `npx create-agentic-pdlc` on a new repo — verify Idea column shows new title/subtitle
- [ ] Run `npx create-agentic-pdlc` — verify default GitHub labels are deleted after setup
- [ ] Close an issue manually — verify `stage:*` labels are removed, `spec:approved` / `qa:approved` remain

Closes #91
Closes #92
Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)