### PR TITLE
feat(template): add prescriptive stage transition rules to AGENTS.md

### DIFF
--- a/.agentic-pdlc/templates/AGENTS.md
+++ b/.agentic-pdlc/templates/AGENTS.md
@@ -73,10 +73,11 @@ MUST NOT add `stage:detailing` label until the user has explicitly confirmed
 the proposed approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
-MUST NOT add `spec:approved` or any approval-trigger label under any
-circumstances — these are set by the PM (human) only, after reviewing the spec
-in the issue body. Adding them triggers irreversible automation (Jules dispatch,
-board move).
+MUST NOT add `spec:approved`, `stage:development`, or manually add
+`stage:approval` — these represent final human approval or the result of it.
+`stage:approval` is only set by system automation after you provide a complete
+spec for human review. Adding them manually triggers irreversible automation
+(Jules dispatch, board move).
 
 Each stage transition requires a fresh explicit signal from the user in the same
 session where the transition happens. These rules have no exceptions.

--- a/.agentic-pdlc/templates/AGENTS.md
+++ b/.agentic-pdlc/templates/AGENTS.md
@@ -64,6 +64,23 @@ When detailing a solution in an issue body, you must **always** include both the
 - `path/to/file.ts` — what changes
 ```
 
+## Stage Transition Rules (non-negotiable)
+
+MUST NOT add `stage:brainstorming` label until exploration findings have been
+presented to the user and the user has responded in the current conversation turn.
+
+MUST NOT add `stage:detailing` label until the user has explicitly confirmed
+the proposed approach in the current conversation turn. Work done in a prior
+planning session does NOT count as confirmation.
+
+MUST NOT add `spec:approved` or any approval-trigger label under any
+circumstances — these are set by the PM (human) only, after reviewing the spec
+in the issue body. Adding them triggers irreversible automation (Jules dispatch,
+board move).
+
+Each stage transition requires a fresh explicit signal from the user in the same
+session where the transition happens. These rules have no exceptions.
+
 ## What NOT to do
 
 - Never commit directly to `main`.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -73,10 +73,11 @@ MUST NOT add `stage:detailing` label until the user has explicitly confirmed
 the proposed approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
-MUST NOT add `spec:approved` or any approval-trigger label under any
-circumstances — these are set by the PM (human) only, after reviewing the spec
-in the issue body. Adding them triggers irreversible automation (Jules dispatch,
-board move).
+MUST NOT add `spec:approved`, `stage:development`, or manually add
+`stage:approval` — these represent final human approval or the result of it.
+`stage:approval` is only set by system automation after you provide a complete
+spec for human review. Adding them manually triggers irreversible automation
+(Jules dispatch, board move).
 
 Each stage transition requires a fresh explicit signal from the user in the same
 session where the transition happens. These rules have no exceptions.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -64,6 +64,23 @@ When detailing a solution in an issue body, you must **always** include both the
 - `path/to/file.ts` — what changes
 ```
 
+## Stage Transition Rules (non-negotiable)
+
+MUST NOT add `stage:brainstorming` label until exploration findings have been
+presented to the user and the user has responded in the current conversation turn.
+
+MUST NOT add `stage:detailing` label until the user has explicitly confirmed
+the proposed approach in the current conversation turn. Work done in a prior
+planning session does NOT count as confirmation.
+
+MUST NOT add `spec:approved` or any approval-trigger label under any
+circumstances — these are set by the PM (human) only, after reviewing the spec
+in the issue body. Adding them triggers irreversible automation (Jules dispatch,
+board move).
+
+Each stage transition requires a fresh explicit signal from the user in the same
+session where the transition happens. These rules have no exceptions.
+
 ## Pipeline Updates
 
 To add or configure optional agents (Jules, QA Agent, Sentinel) at any time:


### PR DESCRIPTION
## Summary

- Adds `## Stage Transition Rules (non-negotiable)` section to `templates/AGENTS.md` and `.agentic-pdlc/templates/AGENTS.md`
- Uses MUST NOT modal language with explicit conditions and closed exception clauses
- Prevents agents from rationalizing past PM gates using descriptive state language

## Test plan

- [ ] Read `templates/AGENTS.md` — confirm `## Stage Transition Rules` section present before `## Pipeline Updates`
- [ ] Read `.agentic-pdlc/templates/AGENTS.md` — confirm same section present before `## What NOT to do`
- [ ] Confirm each rule uses MUST NOT (not "should" / "consider")
- [ ] Confirm `stage:detailing` rule explicitly states "Work done in a prior planning session does NOT count as confirmation."
- [ ] Confirm terminal clause "These rules have no exceptions."

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)