### PR TITLE
feat(template): add explicit PM-only label list to AGENTS.md

### DIFF
--- a/.agentic-pdlc/templates/AGENTS.md
+++ b/.agentic-pdlc/templates/AGENTS.md
@@ -70,6 +70,10 @@ When detailing a solution in an issue body, you must **always** include both the
 - Never open a PR without passing the tests.
 - Never implement beyond the immediate scope of the issue.
 - Never create future-proofing abstractions for hypothetical features.
+- Never add or remove `stage:*`, `qa:*`, or `spec:*` labels manually. The following labels are **reserved for the PM (human) ONLY** — agent MUST NOT apply these under any circumstances:
+  - `spec:approved` — triggers Jules dispatch + board move to Development
+  - `qa:approved` — triggers board move to Code Review
+  - `qa:needs-work` — triggers rework loop
 {{EXTRA_DONT}}
 
 ## Project Standards

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -80,7 +80,10 @@ Run this when the user says anything like "update the pipeline", "update the boa
 - Never open a PR without passing the tests.
 - Never implement beyond the immediate scope of the issue.
 - Never create future-proofing abstractions for hypothetical features.
-- Never add or remove `stage:*` or `qa:*` labels manually. These are owned by GitHub Actions automation and the PM only.
+- Never add or remove `stage:*`, `qa:*`, or `spec:*` labels manually. The following labels are **reserved for the PM (human) ONLY** — agent MUST NOT apply these under any circumstances:
+  - `spec:approved` — triggers Jules dispatch + board move to Development
+  - `qa:approved` — triggers board move to Code Review
+  - `qa:needs-work` — triggers rework loop
 {{EXTRA_DONT}}
 
 ## Project Standards


### PR DESCRIPTION
## Summary

- Replaces vague `stage:*/qa:*` prohibition in `## What NOT to do` with an explicit named list of PM-only labels and their side-effects
- Adds the same named list to `.agentic-pdlc/templates/AGENTS.md` (which was missing any label restriction)
- Root cause: agent added `spec:approved` on a test issue despite generic prohibition, triggering Jules dispatch without human approval

## Test plan

- [ ] Read `templates/AGENTS.md` `## What NOT to do` — confirm named list with `spec:approved`, `qa:approved`, `qa:needs-work`
- [ ] Confirm each entry has a side-effect description (e.g. "triggers Jules dispatch + board move to Development")
- [ ] Confirm modal language: "agent MUST NOT apply these under any circumstances"
- [ ] Read `.agentic-pdlc/templates/AGENTS.md` — confirm same list present and `{{EXTRA_DONT}}` placeholder still intact

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)