### PR TITLE
fix(metrics): show all stages in residence table and fix null maxStage

### DIFF
--- a/.github/workflows/agentic-metrics.yml
+++ b/.github/workflows/agentic-metrics.yml
@@ -311,11 +311,14 @@ jobs:
                 }
                 const avg = arr => arr.reduce((a, b) => a + b, 0) / arr.length;
 
-                let maxStage = null, maxDays = 0;
+                let maxStage = null, maxDays = -1;
                 const rows = [];
                 for (const [stage, label] of STAGES) {
                   const days = byStage[stage];
-                  if (!days) continue;
+                  if (!days) {
+                    rows.push(`| **${label}** | — | — |`);
+                    continue;
+                  }
                   const a = round1(avg(days));
                   rows.push(`| **${label}** | ${a}d | ${days.length} |`);
                   if (a > maxDays) { maxStage = label; maxDays = a; }


### PR DESCRIPTION
## Summary

- `maxDays` initialized to `-1` instead of `0` — when all stage durations round to `0.0`, the condition `a > maxDays` was never true, leaving `maxStage = null` and rendering the string "null" in the insight message
- Stages with no completed transitions now render `| **Stage** | — | — |` instead of being skipped — table always shows all 6 stages

## Test plan

- [ ] Trigger `agentic-metrics.yml` via `workflow_dispatch`
- [ ] Verify Stage Residence Time table shows all 6 stages (Exploration through Testing)
- [ ] Verify stages with no data show `—` in Média and Issues columns
- [ ] Verify insight message shows a valid stage name, never "null"

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)