### PR TITLE
fix(claude-md): enforce spec:approved gate — agent cannot bypass human PM approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,14 @@ Run: `gh issue list --state open --label "stage:development" --json number,title
 # PDLC Stage Gate
 
 NEVER run `gh pr create` unless one of these is true:
-- The linked issue has label `stage:approval`
+- The linked issue has label `spec:approved`
 - The branch name starts with `hotfix/`
 
-Advance stages first: `exploration` → `brainstorming` → `detailing` → `approval`
+NEVER edit files, create branches, or commit unless the linked issue has label `spec:approved` (set by human PM only) or the branch name starts with `hotfix/`.
 
-The PreToolUse hook will block the action automatically if this rule is violated.
+Advance stages first: `exploration` → `brainstorming` → `detailing` → `approval` → (human adds `spec:approved`) → `development`
+
+The PreToolUse hook will block `gh pr create` automatically if this rule is violated.
 
 ## Human-in-the-Loop
 
@@ -27,6 +29,27 @@ The PreToolUse hook will block the action automatically if this rule is violated
 | → `stage:brainstorming` | Ask user — present exploration findings, wait for ok |
 | → `stage:detailing` | Ask user — present brainstorming plan, wait for ok |
 | → `stage:approval` | **Autonomous** — agent completes spec end-to-end, advances without asking |
+| `spec:approved` | **Human PM only** — agent waits; never adds this label |
 | → `stage:development` | Human applies `spec:approved` label — that IS the gate |
 
-**Detailing is fully autonomous.** Write the complete spec, add it to the issue, advance to `stage:approval` — no confirmation needed.
+**Detailing is fully autonomous.** Write the complete spec, add it to the issue, advance to `stage:approval` — no confirmation needed. Then **stop and wait** for human to add `spec:approved` before any implementation.
+
+## Stage Transition Rules (non-negotiable)
+
+MUST NOT add `stage:brainstorming` label until exploration findings have been
+presented to the user and the user has responded in the current conversation turn.
+
+MUST NOT add `stage:detailing` label until the user has explicitly confirmed
+the proposed approach in the current conversation turn. Work done in a prior
+planning session does NOT count as confirmation.
+
+MUST NOT add `spec:approved` or any approval-trigger label under any
+circumstances — these are set by the PM (human) only, after reviewing the spec
+in the issue body. Adding them triggers irreversible automation (Jules dispatch,
+board move).
+
+MUST NOT add or remove `stage:*` or `qa:*` labels outside of the prescribed
+transitions above — these are owned by GitHub Actions automation and the PM.
+
+Each stage transition requires a fresh explicit signal from the user in the same
+session where the transition happens. These rules have no exceptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,10 @@ circumstances — these are set by the PM (human) only, after reviewing the spec
 in the issue body. Adding them triggers irreversible automation (Jules dispatch,
 board move).
 
-MUST NOT add or remove `stage:*` or `qa:*` labels outside of the prescribed
-transitions above — these are owned by GitHub Actions automation and the PM.
+MUST NOT add or remove `stage:development`, `spec:approved`, or `qa:*` labels —
+these are owned by GitHub Actions automation and the PM. The agent is responsible
+for applying `stage:exploration`, `stage:brainstorming`, `stage:detailing`, and
+`stage:approval` as part of the prescribed workflow above.
 
 Each stage transition requires a fresh explicit signal from the user in the same
 session where the transition happens. These rules have no exceptions.

--- a/adapters/hooks/pdlc-stage-gate.sh
+++ b/adapters/hooks/pdlc-stage-gate.sh
@@ -26,8 +26,8 @@ fi
 
 LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
 
-if echo "$LABELS" | grep -qw "stage:approval"; then
-  echo "✅ PDLC: Issue #$ISSUE_NUM approved — gate passed."
+if echo "$LABELS" | grep -qw "spec:approved"; then
+  echo "✅ PDLC: Issue #$ISSUE_NUM spec approved by PM — gate passed."
   exit 0
 fi
 
@@ -39,6 +39,6 @@ fi
 STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
 echo "❌ PDLC Stage Gate: Issue #$ISSUE_NUM is not approved."
 echo "   Current stage: $STAGE"
-echo "   Required: stage:approval or stage:development label on the issue."
+echo "   Required: spec:approved (set by human PM) or stage:development label on the issue."
 echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
 exit 1


### PR DESCRIPTION
## Summary

- PR gate changed from `stage:approval` to `spec:approved` (human-only label)
- Add explicit MUST NOT: edit files / create branch / commit before `spec:approved` on issue
- Add Stage Transition Rules section from template (non-negotiable, verbatim)
- HitL table: new `spec:approved` row marked **Human PM only** — agent stops after `stage:approval` and waits

## Root cause fixed

Before: agent could add `stage:approval` autonomously, then immediately create PR (gate checked `stage:approval`). No human in the loop.

After: gate checks `spec:approved` — a label only the human PM can add. Agent cannot bypass.

## Test plan

- [ ] Verify CLAUDE.md contains `spec:approved` as PR gate
- [ ] Verify MUST NOT implement code before `spec:approved` rule is present
- [ ] Verify Stage Transition Rules section matches template rules
- [ ] Verify HitL table has `spec:approved` row marked as human-only

Closes #109

🤖 **Agent:** Generated with [Claude Code](https://claude.com/claude-code)