### PR TITLE
feat: collapse Exploration into Brainstorming — remove stage:exploration

### DIFF
--- a/.agentic-pdlc/SETUP_PROMPT.md
+++ b/.agentic-pdlc/SETUP_PROMPT.md
@@ -25,7 +25,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    - **Project basics:** Project Name, Description, Technical Stack (Structure), and GitHub Username (for CODEOWNERS security).
    - **Commands:** Test command, Lint command, Build command.
    - **Invariants:** Critical business rules agents must never violate (e.g. Human-in-the-loop).
-   - **Board IDs:** PROJECT_ID, STATUS_FIELD_ID, column option IDs (provide standard PDLC options: Idea, Exploration, Brainstorming, Detail Solution, Approval, Development, Testing, Code Review / PR, Production). Allow user to answer "skip", which means you leave the placeholders intact.
+   - **Board IDs:** PROJECT_ID, STATUS_FIELD_ID, column option IDs (provide standard PDLC options: Idea, Brainstorming, Detail Solution, Approval, Development, Testing, Code Review / PR, Production). Allow user to answer "skip", which means you leave the placeholders intact.
    - **Architecture Violation:** Ask "Does your project use an automated architecture auditing tool (e.g., a CI job that creates issues with an `architecture-violation` label)?". If yes, uncomment the `move-violation-to-board` job inside `project-automation.yml`. If no, ask if they would like help implementing one, reminding them that it significantly improves their agentic development process. If they decline, you can leave the job commented out.
    - **QA Agent (Variant B):** Ask "Do you plan to use an AI QA Agent (e.g. QAWolf or a secondary script) to verify your PRs before Code Review?". If yes, explain you will adopt Variant B: you will change `STATUS_CODE_REVIEW_PR` to `STATUS_TESTING` inside the `move-card-on-pr-open` job in `project-automation.yml` and uncomment the `move-card-on-qa-pass` job. If no, leave the workflow as Variant A (default) and delete the optional `.github/workflows/qa-agent.yml` template.
    - **Implementation agent handle:** e.g., `@google-labs-jules`, or "none". When replacing `{{IMPLEMENTATION_AGENT_LABEL}}` in `agent-trigger.yml`: for Jules use `jules` (the native label the Jules GitHub App watches — **not** `agent:jules`); for other agents use the handle without `@`, lowercase.
@@ -68,6 +68,5 @@ Do not write code for downstream features! Your goal is to refine the Spec, so t
 
 ### 4. Moving the Board (Upstream States)
 As you actively work with the user advancing the feature, you MUST use the GitHub CLI to update internal state labels. This triggers GitHub Actions behind the scenes.
-- Starting context evaluation: Run `gh issue edit <N> --add-label "stage:exploration"`
-- Presenting architecture/approaches: Run `gh issue edit <N> --add-label "stage:brainstorming"`
+- Starting work on an issue (before reading code): Run `gh issue edit <N> --add-label "stage:brainstorming"`
 - Starting to write the technical spec: Run `gh issue edit <N> --add-label "stage:detailing"`

--- a/.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml
@@ -25,7 +25,7 @@ jobs:
             const { owner, repo } = context.repo;
             const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
             const STAGE_LABELS = new Set([
-              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:brainstorming', 'stage:detailing',
               'stage:approval', 'stage:development', 'stage:testing'
             ]);
 
@@ -297,7 +297,6 @@ jobs:
               const records = fs.readFileSync(jsonlPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
               if (records.length > 0) {
                 const STAGES = [
-                  ['stage:exploration',   'Exploration'],
                   ['stage:brainstorming', 'Brainstorming'],
                   ['stage:detailing',     'Detailing'],
                   ['stage:approval',      'Approval'],

--- a/.agentic-pdlc/templates/.github/workflows/pdlc-health-check.yml
+++ b/.agentic-pdlc/templates/.github/workflows/pdlc-health-check.yml
@@ -8,7 +8,6 @@ on:
 env:
   PROJECT_ID: "{{PROJECT_ID}}"
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
-  STATUS_EXPLORATION: "{{ID_EXPLORATION}}"
   STATUS_BRAINSTORMING: "{{ID_BRAINSTORMING}}"
   STATUS_DETAILING: "{{ID_DETAILING}}"
   STATUS_APPROVAL: "{{ID_APPROVAL}}"
@@ -35,7 +34,6 @@ jobs:
             const projectId = process.env.PROJECT_ID;
             const statusFieldId = process.env.STATUS_FIELD_ID;
             const envVars = {
-              'STATUS_EXPLORATION': process.env.STATUS_EXPLORATION,
               'STATUS_BRAINSTORMING': process.env.STATUS_BRAINSTORMING,
               'STATUS_DETAILING': process.env.STATUS_DETAILING,
               'STATUS_APPROVAL': process.env.STATUS_APPROVAL,

--- a/.agentic-pdlc/templates/.github/workflows/project-automation.yml
+++ b/.agentic-pdlc/templates/.github/workflows/project-automation.yml
@@ -12,7 +12,6 @@ env:
   PROJECT_ID: "{{PROJECT_ID}}"
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
   STATUS_IDEA: "{{ID_IDEA}}"
-  STATUS_EXPLORATION: "{{ID_EXPLORATION}}"
   STATUS_BRAINSTORMING: "{{ID_BRAINSTORMING}}"
   STATUS_DETAILING: "{{ID_DETAILING}}"
   STATUS_APPROVAL: "{{ID_APPROVAL}}"
@@ -40,10 +39,7 @@ jobs:
             let targetStatusId = null;
             let stageName = null;
 
-            if (labelName === 'stage:exploration') {
-              targetStatusId = process.env.STATUS_EXPLORATION;
-              stageName = 'Exploration';
-            } else if (labelName === 'stage:brainstorming') {
+            if (labelName === 'stage:brainstorming') {
               targetStatusId = process.env.STATUS_BRAINSTORMING;
               stageName = 'Brainstorming';
             } else if (labelName === 'stage:detailing') {

--- a/.agentic-pdlc/templates/AGENTS.md
+++ b/.agentic-pdlc/templates/AGENTS.md
@@ -30,7 +30,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 ## Mandatory Workflow
 
 0. **Identity**: Always prefix your GitHub comments with `🤖 **Agent:** ` to distinguish yourself.
-1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:exploration` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:exploration"`).
+1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`).
 2. Read the issue entirely — understand its type (US/BUG/TASK/SPIKE) and the Acceptance Criteria.
 3. Read `docs/pdlc.md` — understand the PDLC and the Definition of Done in this project.
 4. Read all files mentioned in the issue's technical context.
@@ -66,11 +66,12 @@ When detailing a solution in an issue body, you must **always** include both the
 
 ## Stage Transition Rules (non-negotiable)
 
-MUST NOT add `stage:brainstorming` label until exploration findings have been
-presented to the user and the user has responded in the current conversation turn.
+MUST apply `stage:brainstorming` label immediately on starting work — before reading
+any code, before invoking any skill. Then read context and present problem summary
++ 2–3 solution options in a single message.
 
-MUST NOT add `stage:detailing` label until the user has explicitly confirmed
-the proposed approach in the current conversation turn. Work done in a prior
+MUST NOT add `stage:detailing` label until the user has explicitly selected
+an approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
 MUST NOT add `spec:approved`, `stage:development`, or manually add

--- a/.agentic-pdlc/templates/docs/pdlc.md
+++ b/.agentic-pdlc/templates/docs/pdlc.md
@@ -4,9 +4,8 @@
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
-| 💡 Idea — don't move manually to Exploration | Backlog — tell agent: "work on issue #XX" | Don't move manually |
-| 🔍 Exploration | Claude is analyzing code and context | Label `stage:exploration` |
-| 🧠 Brainstorming | Claude proposed approaches, awaiting PM gate | Label `stage:brainstorming` |
+| 💡 Idea | Backlog — tell agent: "work on issue #XX" | Don't move manually |
+| 🧠 Brainstorming | AI reading context, proposing approaches and trade-offs | Label `stage:brainstorming` |
 | 📐 Detail Solution | Claude is writing the technical spec | Label `stage:detailing` |
 | ✅ Approval | Spec ready, awaiting `spec:approved` label | Label `spec:approved` |
 | ⚙️ Development | Agent implementing the spec | Label `stage:development` |
@@ -37,7 +36,6 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | Column | Option ID |
 |---|---|
 | 💡 Idea | `{{ID_IDEA}}` |
-| 🔍 Exploration | `{{ID_EXPLORATION}}` |
 | 🧠 Brainstorming | `{{ID_BRAINSTORMING}}` |
 | 📐 Detail Solution | `{{ID_DETAIL}}` |
 | ✅ Approval | `{{ID_APPROVAL}}` |
@@ -70,7 +68,6 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 
 | Label | Entity | Color | Meaning |
 |---|---|---|---|
-| `stage:exploration` | Issue | Purple | Issue is being evaluated |
 | `stage:brainstorming` | Issue | Pink | Proposed approaches awaiting PM gate |
 | `stage:detailing` | Issue | Blue | Technical spec is being written |
 | `stage:development` | Issue | Orange | Agent is implementing the spec |
@@ -85,8 +82,8 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 ## Approval Gates
 
 **Gate 1 — PM/Ideation (Brainstorming):**
-You comment on the issue approving one of the approaches proposed by the ideation agent.
-Format: *"Approved — proceed with option X."*
+Agent presents problem summary + 2–3 solution options in a single message. You select an approach.
+Format: *"Option X"* or *"Go with B"* or *"Approved — proceed with option X."*
 
 **Gate 2 — Tech Lead (Spec):**
 You add the `spec:approved` label to the issue after reviewing the technical spec in the body.
@@ -98,10 +95,10 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 
 | Label | Flow |
 |---|---|
-| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
+| `type:us` | brainstorming → Gate 1 → detailing → approval |
+| `type:task` | brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 

--- a/.agentic-setup-prompt.md
+++ b/.agentic-setup-prompt.md
@@ -25,7 +25,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    - **Project basics:** Project Name, Description, Technical Stack (Structure), and GitHub Username (for CODEOWNERS security).
    - **Commands:** Test command, Lint command, Build command.
    - **Invariants:** Critical business rules agents must never violate (e.g. Human-in-the-loop).
-   - **Board IDs:** PROJECT_ID, STATUS_FIELD_ID, column option IDs (provide standard PDLC options: Idea, Exploration, Brainstorming, Detail Solution, Approval, Development, Testing, Code Review / PR, Production). Allow user to answer "skip", which means you leave the placeholders intact.
+   - **Board IDs:** PROJECT_ID, STATUS_FIELD_ID, column option IDs (provide standard PDLC options: Idea, Brainstorming, Detail Solution, Approval, Development, Testing, Code Review / PR, Production). Allow user to answer "skip", which means you leave the placeholders intact.
    - **Architecture Violation:** Ask "Does your project use an automated architecture auditing tool (e.g., a CI job that creates issues with an `architecture-violation` label)?". If yes, uncomment the `move-violation-to-board` job inside `project-automation.yml`. If no, ask if they would like help implementing one, reminding them that it significantly improves their agentic development process. If they decline, you can leave the job commented out.
    - **QA Agent (Variant B):** Ask "Do you plan to use an AI QA Agent (e.g. QAWolf or a secondary script) to verify your PRs before Code Review?". If yes, explain you will adopt Variant B: you will change `STATUS_CODE_REVIEW_PR` to `STATUS_TESTING` inside the `move-card-on-pr-open` job in `project-automation.yml` and uncomment the `move-card-on-qa-pass` job. If no, leave the workflow as Variant A (default) and delete the optional `.github/workflows/qa-agent.yml` template.
    - **Implementation agent handle:** e.g., `@google-labs-jules`, or "none". When replacing `{{IMPLEMENTATION_AGENT_LABEL}}` in `agent-trigger.yml`: for Jules use `jules` (the native label the Jules GitHub App watches — **not** `agent:jules`); for other agents use the handle without `@`, lowercase.
@@ -68,6 +68,5 @@ Do not write code for downstream features! Your goal is to refine the Spec, so t
 
 ### 4. Moving the Board (Upstream States)
 As you actively work with the user advancing the feature, you MUST use the GitHub CLI to update internal state labels. This triggers GitHub Actions behind the scenes.
-- Starting context evaluation: Run `gh issue edit <N> --add-label "stage:exploration"`
-- Presenting architecture/approaches: Run `gh issue edit <N> --add-label "stage:brainstorming"`
+- Starting work on an issue (before reading code): Run `gh issue edit <N> --add-label "stage:brainstorming"`
 - Starting to write the technical spec: Run `gh issue edit <N> --add-label "stage:detailing"`

--- a/.agentic-setup.md
+++ b/.agentic-setup.md
@@ -25,7 +25,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    - **Project basics:** Project Name, Description, Technical Stack (Structure), and GitHub Username (for CODEOWNERS security).
    - **Commands:** Test command, Lint command, Build command.
    - **Invariants:** Critical business rules agents must never violate (e.g. Human-in-the-loop).
-   - **Board IDs:** PROJECT_ID, STATUS_FIELD_ID, column option IDs (provide standard PDLC options: Idea, Exploration, Brainstorming, Detail Solution, Approval, Development, Testing, Code Review / PR, Production). Allow user to answer "skip", which means you leave the placeholders intact.
+   - **Board IDs:** PROJECT_ID, STATUS_FIELD_ID, column option IDs (provide standard PDLC options: Idea, Brainstorming, Detail Solution, Approval, Development, Testing, Code Review / PR, Production). Allow user to answer "skip", which means you leave the placeholders intact.
    - **Architecture Violation:** Ask "Does your project use an automated architecture auditing tool (e.g., a CI job that creates issues with an `architecture-violation` label)?". If yes, uncomment the `move-violation-to-board` job inside `project-automation.yml`. If no, ask if they would like help implementing one, reminding them that it significantly improves their agentic development process. If they decline, you can leave the job commented out.
    - **QA Agent (Variant B):** Ask "Do you plan to use an AI QA Agent (e.g. QAWolf or a secondary script) to verify your PRs before Code Review?". If yes, explain you will adopt Variant B: you will change `STATUS_CODE_REVIEW_PR` to `STATUS_TESTING` inside the `move-card-on-pr-open` job in `project-automation.yml` and uncomment the `move-card-on-qa-pass` job. If no, leave the workflow as Variant A (default) and delete the optional `.github/workflows/qa-agent.yml` template.
    - **Implementation agent handle:** e.g., `@google-labs-jules`, or "none". When replacing `{{IMPLEMENTATION_AGENT_LABEL}}` in `agent-trigger.yml`: for Jules use `jules` (the native label the Jules GitHub App watches — **not** `agent:jules`); for other agents use the handle without `@`, lowercase.
@@ -68,6 +68,5 @@ Do not write code for downstream features! Your goal is to refine the Spec, so t
 
 ### 4. Moving the Board (Upstream States)
 As you actively work with the user advancing the feature, you MUST use the GitHub CLI to update internal state labels. This triggers GitHub Actions behind the scenes.
-- Starting context evaluation: Run `gh issue edit <N> --add-label "stage:exploration"`
-- Presenting architecture/approaches: Run `gh issue edit <N> --add-label "stage:brainstorming"`
+- Starting work on an issue (before reading code): Run `gh issue edit <N> --add-label "stage:brainstorming"`
 - Starting to write the technical spec: Run `gh issue edit <N> --add-label "stage:detailing"`

--- a/.github/workflows/agentic-metrics.yml
+++ b/.github/workflows/agentic-metrics.yml
@@ -25,7 +25,7 @@ jobs:
             const { owner, repo } = context.repo;
             const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
             const STAGE_LABELS = new Set([
-              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:brainstorming', 'stage:detailing',
               'stage:approval', 'stage:development', 'stage:testing'
             ]);
 
@@ -297,7 +297,6 @@ jobs:
               const records = fs.readFileSync(jsonlPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
               if (records.length > 0) {
                 const STAGES = [
-                  ['stage:exploration',   'Exploration'],
                   ['stage:brainstorming', 'Brainstorming'],
                   ['stage:detailing',     'Detailing'],
                   ['stage:approval',      'Approval'],

--- a/.github/workflows/pdlc-health-check.yml
+++ b/.github/workflows/pdlc-health-check.yml
@@ -8,7 +8,6 @@ on:
 env:
   PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
   STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
-  STATUS_EXPLORATION: "96ac537d"
   STATUS_BRAINSTORMING: "8eb07c5b"
   STATUS_DETAILING: "9f6ce70e"
   STATUS_APPROVAL: "31bf4610"
@@ -35,7 +34,6 @@ jobs:
             const projectId = process.env.PROJECT_ID;
             const statusFieldId = process.env.STATUS_FIELD_ID;
             const envVars = {
-              'STATUS_EXPLORATION': process.env.STATUS_EXPLORATION,
               'STATUS_BRAINSTORMING': process.env.STATUS_BRAINSTORMING,
               'STATUS_DETAILING': process.env.STATUS_DETAILING,
               'STATUS_APPROVAL': process.env.STATUS_APPROVAL,

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -12,7 +12,6 @@ env:
   PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
   STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
   STATUS_IDEA: "bb6e5a20"
-  STATUS_EXPLORATION: "96ac537d"
   STATUS_BRAINSTORMING: "8eb07c5b"
   STATUS_DETAILING: "9f6ce70e"
   STATUS_APPROVAL: "31bf4610"
@@ -40,10 +39,7 @@ jobs:
             let targetStatusId = null;
             let stageName = null;
 
-            if (labelName === 'stage:exploration') {
-              targetStatusId = process.env.STATUS_EXPLORATION;
-              stageName = 'Exploration';
-            } else if (labelName === 'stage:brainstorming') {
+            if (labelName === 'stage:brainstorming') {
               targetStatusId = process.env.STATUS_BRAINSTORMING;
               stageName = 'Brainstorming';
             } else if (labelName === 'stage:detailing') {
@@ -302,7 +298,7 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
             const toRemove = [
-              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:brainstorming', 'stage:detailing',
               'stage:approval', 'stage:development', 'stage:testing',
               'agent:working', 'qa:needs-work', 'pr:in-review', 'jules'
             ];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 ## Mandatory Workflow
 
 0. **Identity**: Always prefix your GitHub comments with `🤖 **Agent:** ` to distinguish yourself.
-1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:exploration` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:exploration"`).
+1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`).
 2. Read the issue entirely — understand its type (US/BUG/TASK/SPIKE) and the Acceptance Criteria.
 3. Read `docs/pdlc.md` — understand the PDLC and the Definition of Done in this project.
 4. Read all files mentioned in the issue's technical context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **What it is:** npm CLI (`npx create-agentic-pdlc`) that installs a PDLC workflow for AI agent projects. Stack: Markdown + GitHub Actions YAML only — never complex Node/Python/Bash scripts.
 
-**Workflow:** `stage:exploration` → `stage:brainstorming` → `stage:detailing` → `spec:approved` → `stage:development` → PR → merge. Labels move the board automatically.
+**Workflow:** `stage:brainstorming` → `stage:detailing` → `spec:approved` → `stage:development` → PR → merge. Labels move the board automatically.
 
 ## Session Startup
 
@@ -17,7 +17,7 @@ NEVER run `gh pr create` unless one of these is true:
 
 NEVER edit files, create branches, or commit unless the linked issue has label `spec:approved` (set by human PM only) or the branch name starts with `hotfix/`.
 
-Advance stages first: `exploration` → `brainstorming` → `detailing` → `approval` → (human adds `spec:approved`) → `development`
+Advance stages first: `brainstorming` → `detailing` → `approval` → (human adds `spec:approved`) → `development`
 
 The PreToolUse hook will block `gh pr create` automatically if this rule is violated.
 
@@ -25,9 +25,8 @@ The PreToolUse hook will block `gh pr create` automatically if this rule is viol
 
 | Transition | Gate |
 |---|---|
-| → `stage:exploration` | Autonomous — apply immediately |
-| → `stage:brainstorming` | Ask user — present exploration findings, wait for ok |
-| → `stage:detailing` | Ask user — present brainstorming plan, wait for ok |
+| → `stage:brainstorming` | Autonomous — apply immediately |
+| → `stage:detailing` | Ask user — present problem summary + options, wait for choice |
 | → `stage:approval` | **Autonomous** — agent completes spec end-to-end, advances without asking |
 | `spec:approved` | **Human PM only** — agent waits; never adds this label |
 | → `stage:development` | Human applies `spec:approved` label — that IS the gate |
@@ -36,11 +35,12 @@ The PreToolUse hook will block `gh pr create` automatically if this rule is viol
 
 ## Stage Transition Rules (non-negotiable)
 
-MUST NOT add `stage:brainstorming` label until exploration findings have been
-presented to the user and the user has responded in the current conversation turn.
+MUST apply `stage:brainstorming` label immediately on starting work — before
+reading any code, before invoking any skill. Then read context and present
+problem summary + 2–3 solution options in a single message.
 
-MUST NOT add `stage:detailing` label until the user has explicitly confirmed
-the proposed approach in the current conversation turn. Work done in a prior
+MUST NOT add `stage:detailing` label until the user has explicitly selected
+an approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
 MUST NOT add `spec:approved` or any approval-trigger label under any
@@ -50,8 +50,8 @@ board move).
 
 MUST NOT add or remove `stage:development`, `spec:approved`, or `qa:*` labels —
 these are owned by GitHub Actions automation and the PM. The agent is responsible
-for applying `stage:exploration`, `stage:brainstorming`, `stage:detailing`, and
-`stage:approval` as part of the prescribed workflow above.
+for applying `stage:brainstorming`, `stage:detailing`, and `stage:approval` as
+part of the prescribed workflow above.
 
 Each stage transition requires a fresh explicit signal from the user in the same
 session where the transition happens. These rules have no exceptions.

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -102,9 +102,9 @@ If `AGENTS.md` and `docs/pdlc.md` are present, you are in **Execution Mode**.
 
 ### 0. [FIRST] Issue Type Identification
 
-**Run before anything else — before `stage:exploration`, before reading code.**
+**Run before anything else — before reading code.**
 
-Reading the issue title and body for type inference is exempt from the `stage:exploration` requirement: it is metadata already present in the request, not code reading or skill invocation.
+Reading the issue title and body for type inference is exempt from the initial label requirement: it is metadata already present in the request, not code reading or skill invocation.
 
 1. Check if issue already has a `type:*` label (`type:us`, `type:task`, `type:bug`, `type:spike`) → if yes, skip to Section 0.1.
 2. Read issue title + body (metadata only — no code reading at this step).
@@ -120,10 +120,10 @@ Reading the issue title and body for type inference is exempt from the `stage:ex
 
 | Type | Flow |
 |---|---|
-| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
+| `type:us` | brainstorming → Gate 1 → detailing → approval |
+| `type:task` | brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 ### 0.1 Board Labels — Mandatory at Every State Transition
 
@@ -131,11 +131,10 @@ These label commands are non-negotiable. They run **before** the activity they a
 
 | When | Command |
 |---|---|
-| Before reading any code / invoking any skill | `gh issue edit <N> --add-label "stage:exploration"` |
-| Before presenting architecture approaches | `gh issue edit <N> --add-label "stage:brainstorming" --remove-label "stage:exploration"` |
+| Before reading any code / invoking any skill | `gh issue edit <N> --add-label "stage:brainstorming"` |
 | Before writing the technical spec | `gh issue edit <N> --add-label "stage:detailing" --remove-label "stage:brainstorming"` |
 
-No investigation, no skill invocation, no code reading happens before `stage:exploration` is applied. No architecture presentation starts before `stage:brainstorming` is set (and `stage:exploration` removed). No spec writing starts before `stage:detailing` is set (and `stage:brainstorming` removed).
+No investigation, no skill invocation, no code reading happens before `stage:brainstorming` is applied. No spec writing starts before `stage:detailing` is set (and `stage:brainstorming` removed).
 
 ### 0.1 PR Stage Gate — Non-Negotiable
 
@@ -151,7 +150,7 @@ git checkout -b hotfix/<N>-<description>
 ```
 
 ### 1. Daily Upstream Loop
-Your job is to move issues from "💡 Idea - don't move manually to Exploration" to "📐 Detail Solution".
+Your job is to move issues from "💡 Idea" to "📐 Detail Solution".
 When asked to work on a feature, you will:
 - Explore the code context.
 - Present architectural approaches (Brainstorming).

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -5,8 +5,7 @@ This document describes the full lifecycle of a card on the agentic-pdlc board �
 ```mermaid
 stateDiagram-v2
     direction LR
-    Idea --> Exploration : stage:exploration
-    Exploration --> Brainstorming : stage:brainstorming
+    Idea --> Brainstorming : stage:brainstorming
     Brainstorming --> Detailing : Gate 1 (PM)
     Detailing --> Approval : stage:approval
     Approval --> Development : Gate 2 (spec:approved)
@@ -23,7 +22,7 @@ stateDiagram-v2
 |------|---------------|
 | **PM** (human) | Selects issues for the sprint, approves brainstorm (Gate 1), approves spec (Gate 2) |
 | **TL / Reviewer** (human) | Co-approves spec for technical decisions (Gate 2), reviews and approves the PR (Gate 3) |
-| **Claude** | Exploration, brainstorming, spec writing — acts on PM instruction via chat or via upstream label |
+| **Claude** | Brainstorming (context reading + approaches), spec writing — acts on PM instruction via chat or via upstream label |
 | **Implementation Agent** | Implementation, running tests, opening the PR |
 | **Workflow** | All label swaps and card movements — the source of truth for board state |
 
@@ -38,33 +37,22 @@ Issue exists in the backlog with no `stage:` label.
 
 ---
 
-### 🔍 Exploration
-
-**Trigger (two equivalent paths):**
-- PM tells Claude directly in chat → Claude adds `stage:exploration` to the issue, OR
-- PM adds `stage:exploration` directly to the issue
-
-**Workflow:** `project-automation.yml` detects `stage:exploration` → moves card to Exploration.
-
-**Who works:** Claude reads relevant code and context.
-
----
-
 ### 🧠 Brainstorming
 
-**Trigger:** Claude, after exploration.
+**Trigger:** PM tells Claude to work on the issue (in chat) or applies `stage:brainstorming` directly.
 
 **Actions:**
-- Claude posts a comment on the issue with findings and 2–3 proposed approaches
-- Claude swaps `stage:exploration` → `stage:brainstorming`
+- Claude applies `stage:brainstorming` immediately
+- Claude reads relevant code and context
+- Claude posts a single comment with: (1) brief problem summary, (2) 2–3 proposed approaches with trade-offs
 
-**Workflow:** `project-automation.yml` moves card to Brainstorming.
+**Workflow:** `project-automation.yml` detects `stage:brainstorming` → moves card to Brainstorming.
 
 **⏸ Human gate (Gate 1 — PM):** PM reads the brainstorming comment and selects an approach. This can be done:
 - By commenting on the issue (e.g., "Option A", "Go with B", "approved", "lgtm")
 - By telling Claude in chat
 
-**Note on implicit approval:** If Claude presented multiple options, selecting one (e.g., "Option A") counts as implicit approval. The `upstream-gate.yml` detects option-selection patterns in addition to explicit approval words.
+**Note on implicit approval:** Selecting one option (e.g., "Option A") counts as implicit approval. The `upstream-gate.yml` detects option-selection patterns in addition to explicit approval words.
 
 ---
 
@@ -141,7 +129,6 @@ Issue exists in the backlog with no `stage:` label.
 
 | Label | Added by | Removed by |
 |-------|----------|------------|
-| `stage:exploration` | PM (human) or Claude | Claude |
 | `stage:brainstorming` | Claude | `upstream-gate.yml` |
 | `stage:detailing` | `upstream-gate.yml` | Claude |
 | `stage:approval` | Claude | `agent-trigger.yml` |

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -4,9 +4,8 @@
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
-| 💡 Idea — don't move manually to Exploration | Backlog — tell agent: "work on issue #XX" | Don't move manually |
-| 🔍 Exploration | AI is analyzing code and context | Label `stage:exploration` |
-| 🧠 Brainstorming | AI proposed approaches and trade-offs | Label `stage:brainstorming` |
+| 💡 Idea | Backlog — tell agent: "work on issue #XX" | Don't move manually |
+| 🧠 Brainstorming | AI reading context, proposing approaches and trade-offs | Label `stage:brainstorming` |
 | 📐 Detail Solution | AI is writing the technical spec | Label `stage:detailing` |
 | ✅ Approval | Your turn, awaiting `spec:approved` label | Label `spec:approved` |
 | ⚙️ Development | AI implementing the spec | Label `stage:development` |
@@ -32,7 +31,6 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | Column | Option ID |
 |---|---|
 | 💡 Idea | `{{ID_IDEA}}` |
-| 🔍 Exploration | `{{ID_EXPLORATION}}` |
 | 🧠 Brainstorming | `{{ID_BRAINSTORMING}}` |
 | 📐 Detail Solution | `{{ID_DETAIL}}` |
 | ✅ Approval | `{{ID_APPROVAL}}` |
@@ -65,7 +63,6 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 
 | Label | Entity | Color | Meaning |
 |---|---|---|---|
-| `stage:exploration` | Issue | Purple | Issue is being evaluated |
 | `stage:brainstorming` | Issue | Pink | Proposed approaches awaiting PM gate |
 | `stage:detailing` | Issue | Blue | Technical spec is being written |
 | `stage:development` | Issue | Orange | Agent is implementing the spec |
@@ -80,8 +77,8 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 ## Approval Gates
 
 **Gate 1 — PM/Ideation (Brainstorming):**
-You comment on the issue approving one of the approaches proposed by the ideation agent.
-Format: *"Approved — proceed with option X."*
+Agent presents problem summary + 2–3 solution options in a single message. You select an approach.
+Format: *"Option X"* or *"Go with B"* or *"Approved — proceed with option X."*
 
 **Gate 2 — Tech Lead (Spec):**
 You add the `spec:approved` label to the issue after reviewing the technical spec in the body.
@@ -93,10 +90,10 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 
 | Label | Flow |
 |---|---|
-| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
+| `type:us` | brainstorming → Gate 1 → detailing → approval |
+| `type:task` | brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 

--- a/templates/.github/workflows/pdlc-health-check.yml
+++ b/templates/.github/workflows/pdlc-health-check.yml
@@ -8,7 +8,6 @@ on:
 env:
   PROJECT_ID: "{{PROJECT_ID}}"
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
-  STATUS_EXPLORATION: "{{ID_EXPLORATION}}"
   STATUS_BRAINSTORMING: "{{ID_BRAINSTORMING}}"
   STATUS_DETAILING: "{{ID_DETAILING}}"
   STATUS_APPROVAL: "{{ID_APPROVAL}}"
@@ -35,7 +34,6 @@ jobs:
             const projectId = process.env.PROJECT_ID;
             const statusFieldId = process.env.STATUS_FIELD_ID;
             const envVars = {
-              'STATUS_EXPLORATION': process.env.STATUS_EXPLORATION,
               'STATUS_BRAINSTORMING': process.env.STATUS_BRAINSTORMING,
               'STATUS_DETAILING': process.env.STATUS_DETAILING,
               'STATUS_APPROVAL': process.env.STATUS_APPROVAL,

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -12,7 +12,6 @@ env:
   PROJECT_ID: "{{PROJECT_ID}}"
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
   STATUS_IDEA: "{{ID_IDEA}}"
-  STATUS_EXPLORATION: "{{ID_EXPLORATION}}"
   STATUS_BRAINSTORMING: "{{ID_BRAINSTORMING}}"
   STATUS_DETAILING: "{{ID_DETAILING}}"
   STATUS_APPROVAL: "{{ID_APPROVAL}}"
@@ -40,10 +39,7 @@ jobs:
             let targetStatusId = null;
             let stageName = null;
 
-            if (labelName === 'stage:exploration') {
-              targetStatusId = process.env.STATUS_EXPLORATION;
-              stageName = 'Exploration';
-            } else if (labelName === 'stage:brainstorming') {
+            if (labelName === 'stage:brainstorming') {
               targetStatusId = process.env.STATUS_BRAINSTORMING;
               stageName = 'Brainstorming';
             } else if (labelName === 'stage:detailing') {
@@ -316,7 +312,7 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
             const toRemove = [
-              'stage:exploration', 'stage:brainstorming', 'stage:detailing',
+              'stage:brainstorming', 'stage:detailing',
               'stage:approval', 'stage:development', 'stage:testing',
               'agent:working', 'qa:needs-work', 'pr:in-review', 'jules'
             ];

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -30,7 +30,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 ## Mandatory Workflow
 
 0. **Identity**: Always prefix your GitHub comments with `🤖 **Agent:** ` to distinguish yourself.
-1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:exploration` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:exploration"`).
+1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`).
 2. Read the issue entirely — understand its type (US/BUG/TASK/SPIKE) and the Acceptance Criteria.
 3. Read `docs/pdlc.md` — understand the PDLC and the Definition of Done in this project.
 4. Read all files mentioned in the issue's technical context.
@@ -66,11 +66,12 @@ When detailing a solution in an issue body, you must **always** include both the
 
 ## Stage Transition Rules (non-negotiable)
 
-MUST NOT add `stage:brainstorming` label until exploration findings have been
-presented to the user and the user has responded in the current conversation turn.
+MUST apply `stage:brainstorming` label immediately on starting work — before reading
+any code, before invoking any skill. Then read context and present problem summary
++ 2–3 solution options in a single message.
 
-MUST NOT add `stage:detailing` label until the user has explicitly confirmed
-the proposed approach in the current conversation turn. Work done in a prior
+MUST NOT add `stage:detailing` label until the user has explicitly selected
+an approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
 MUST NOT add `spec:approved`, `stage:development`, or manually add
@@ -102,7 +103,7 @@ Run this when the user says anything like "update the pipeline", "update the boa
   - `spec:approved`: triggers Jules dispatch + board move to Development.
   - `qa:approved`: triggers board move to Code Review.
   - `qa:needs-work`: signals the PR requires changes and halts the flow.
-- Never add or remove stage:* labels manually, except for stage:exploration as required by the workflow (metadata-only actions are exempt). These are owned by GitHub Actions automation and the PM.
+- Never add or remove stage:* labels manually, except for stage:brainstorming as the initial label when starting work. All other stage transitions are owned by GitHub Actions automation and the PM.
 {{EXTRA_DONT}}
 
 ## Project Standards

--- a/templates/docs/pdlc.md
+++ b/templates/docs/pdlc.md
@@ -4,9 +4,8 @@
 
 | Column | Meaning | Who moves the card |
 |---|---|---|
-| 💡 Idea — don't move manually to Exploration | Backlog — tell agent: "work on issue #XX" | Don't move manually |
-| 🔍 Exploration | Claude is analyzing code and context | Label `stage:exploration` |
-| 🧠 Brainstorming | Claude proposed approaches, awaiting PM gate | Label `stage:brainstorming` |
+| 💡 Idea | Backlog — tell agent: "work on issue #XX" | Don't move manually |
+| 🧠 Brainstorming | AI reading context, proposing approaches and trade-offs | Label `stage:brainstorming` |
 | 📐 Detail Solution | Claude is writing the technical spec | Label `stage:detailing` |
 | ✅ Approval | Spec ready, awaiting `spec:approved` label | Label `spec:approved` |
 | ⚙️ Development | Agent implementing the spec | Label `stage:development` |
@@ -37,7 +36,6 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 | Column | Option ID |
 |---|---|
 | 💡 Idea | `{{ID_IDEA}}` |
-| 🔍 Exploration | `{{ID_EXPLORATION}}` |
 | 🧠 Brainstorming | `{{ID_BRAINSTORMING}}` |
 | 📐 Detail Solution | `{{ID_DETAIL}}` |
 | ✅ Approval | `{{ID_APPROVAL}}` |
@@ -70,7 +68,6 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 
 | Label | Entity | Color | Meaning |
 |---|---|---|---|
-| `stage:exploration` | Issue | Purple | Issue is being evaluated |
 | `stage:brainstorming` | Issue | Pink | Proposed approaches awaiting PM gate |
 | `stage:detailing` | Issue | Blue | Technical spec is being written |
 | `stage:development` | Issue | Orange | Agent is implementing the spec |
@@ -88,8 +85,8 @@ REPO         = {{REPO_OWNER}}/{{REPO_NAME}}
 ## Approval Gates
 
 **Gate 1 — PM/Ideation (Brainstorming):**
-You comment on the issue approving one of the approaches proposed by the ideation agent.
-Format: *"Approved — proceed with option X."*
+Agent presents problem summary + 2–3 solution options in a single message. You select an approach.
+Format: *"Option X"* or *"Go with B"* or *"Approved — proceed with option X."*
 
 **Gate 2 — Tech Lead (Spec):**
 You add the `spec:approved` label to the issue after reviewing the technical spec in the body.
@@ -101,10 +98,10 @@ The `type:*` label is the authoritative signal — set automatically by the agen
 
 | Label | Flow |
 |---|---|
-| `type:us` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:task` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:bug` | exploration → brainstorming → Gate 1 → detailing → approval |
-| `type:spike` | exploration → brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
+| `type:us` | brainstorming → Gate 1 → detailing → approval |
+| `type:task` | brainstorming → Gate 1 → detailing → approval |
+| `type:bug` | brainstorming → Gate 1 → detailing → approval |
+| `type:spike` | brainstorming → Gate 1 → detailing → conclusion comment (never reaches Development) |
 
 If no `type:*` label present and agent confidence < 85%, defaults to `type:us` (safe fallback — never skips gates by omission).
 


### PR DESCRIPTION
## Summary

- Removes `stage:exploration` as a distinct board phase — agent now applies `stage:brainstorming` immediately on starting work, reads context, and presents problem summary + options in a single message
- Eliminates the confirmatory gate between Exploration and Brainstorming that produced no new insights for solo devs
- Updates all agent instructions, board docs, setup prompts, and GitHub Actions across root + templates (17 files + 3 health-check files discovered during execution)

## Changes

- `CLAUDE.md` + `AGENTS.md` — gate table and initial state label
- `adapters/claude-code/skill.md` — board labels table, type flow table, section 0 instructions
- `docs/pdlc.md` + `docs/flow.md` — board columns, labels, approval gates, flow diagram
- `.agentic-setup.md`, `.agentic-setup-prompt.md`, `.agentic-pdlc/SETUP_PROMPT.md` — board IDs question and moving-the-board section
- `.github/workflows/project-automation.yml` + `agentic-metrics.yml` + `pdlc-health-check.yml` — remove `STATUS_EXPLORATION` env var and label handlers
- All 3 template copies of each file above

## Design

Spec: `docs/superpowers/specs/2026-05-23-collapse-exploration-brainstorming-design.md`
Plan: `docs/superpowers/plans/2026-05-23-collapse-exploration-brainstorming.md`

## Test Plan

- [x] `git grep "stage:exploration" -- '*.md' '*.yml'` returns only historical spike doc
- [x] 13 commits, all mechanical find+replace, verified per-file after each task

Closes #113