### PR TITLE
fix(metrics): upsert pulse issue on same-week re-run

### DIFF
--- a/.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml
+++ b/.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml
@@ -393,19 +393,27 @@ jobs:
               console.log(`Created label ${LABEL}`);
             }
 
-            // Close previous pulse issues
+            // Close previous pulse issues; upsert if same week already exists
             const prev = await github.rest.issues.listForRepo({
               owner, repo, labels: LABEL, state: 'open', per_page: 20
             });
+            let existingIssue = null;
             for (const issue of prev.data) {
-              if (issue.title !== title) {
+              if (issue.title === title) {
+                existingIssue = issue;
+                console.log(`Found existing pulse for ${title}: #${issue.number} — will update body`);
+              } else {
                 await github.rest.issues.update({ owner, repo, issue_number: issue.number, state: 'closed' });
                 console.log(`Closed previous pulse: #${issue.number}`);
               }
             }
 
-            // Create new pulse issue
-            const created = await github.rest.issues.create({
-              owner, repo, title, body, labels: [LABEL]
-            });
-            console.log(`✅ Created pulse issue: #${created.data.number} — ${title}`);
+            if (existingIssue) {
+              await github.rest.issues.update({ owner, repo, issue_number: existingIssue.number, body });
+              console.log(`✅ Updated pulse issue: #${existingIssue.number} — ${title}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner, repo, title, body, labels: [LABEL]
+              });
+              console.log(`✅ Created pulse issue: #${created.data.number} — ${title}`);
+            }

--- a/.github/workflows/agentic-metrics.yml
+++ b/.github/workflows/agentic-metrics.yml
@@ -396,19 +396,27 @@ jobs:
               console.log(`Created label ${LABEL}`);
             }
 
-            // Close previous pulse issues
+            // Close previous pulse issues; upsert if same week already exists
             const prev = await github.rest.issues.listForRepo({
               owner, repo, labels: LABEL, state: 'open', per_page: 20
             });
+            let existingIssue = null;
             for (const issue of prev.data) {
-              if (issue.title !== title) {
+              if (issue.title === title) {
+                existingIssue = issue;
+                console.log(`Found existing pulse for ${title}: #${issue.number} — will update body`);
+              } else {
                 await github.rest.issues.update({ owner, repo, issue_number: issue.number, state: 'closed' });
                 console.log(`Closed previous pulse: #${issue.number}`);
               }
             }
 
-            // Create new pulse issue
-            const created = await github.rest.issues.create({
-              owner, repo, title, body, labels: [LABEL]
-            });
-            console.log(`✅ Created pulse issue: #${created.data.number} — ${title}`);
+            if (existingIssue) {
+              await github.rest.issues.update({ owner, repo, issue_number: existingIssue.number, body });
+              console.log(`✅ Updated pulse issue: #${existingIssue.number} — ${title}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner, repo, title, body, labels: [LABEL]
+              });
+              console.log(`✅ Created pulse issue: #${created.data.number} — ${title}`);
+            }


### PR DESCRIPTION
## Summary

- **Root cause:** `workflow_dispatch` mid-week and the Sunday cron compute the same ISO `weekKey` (Sunday is the last day of an ISO week, not the first). Dedup loop correctly skipped closing the existing issue but `create` was unconditional → duplicate issues with identical titles.
- **Fix:** Collect a reference to the existing same-week issue in the loop, then either update its body (upsert) or create fresh — never both.
- Both `.github/workflows/agentic-metrics.yml` and `.agentic-pdlc/templates/.github/workflows/agentic-metrics.yml` updated identically.

## Test plan

- [ ] Trigger `workflow_dispatch` during the current ISO week → existing pulse body updated, no new issue created
- [ ] Trigger `workflow_dispatch` in a new week → previous pulse closed, new issue created
- [ ] Verify console logs: `Found existing pulse…` on re-run, `✅ Created pulse issue…` on first run of a new week

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)