### PR TITLE
feat: upgrade spec format to 7-section standard in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,43 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 7. Run typecheck: `echo "No typecheck needed."`
 8. Create a Pull Request with `Closes #N` in the body — automation moves the board.
 
+## Spec Format
+
+When writing or rewriting an issue body during detailing, include ALL sections below. Omitting any section blocks `stage:approval`.
+
+```
+## Problem
+[1-3 sentences. What fails. Who affected. Measured impact.]
+
+## Sprint Goal / Success Metrics
+| Metric | Baseline | Target | When |
+|--------|----------|--------|------|
+
+## Solution
+[Behavioral description of what is built. No implementation details.]
+
+## Acceptance Criteria
+**AC1 — [name]**
+- Given [precondition]
+- When [action]
+- Then [outcome]
+
+## Edge Cases
+- EC1: [condition] → [expected behavior]
+
+## Out of Scope
+- [item] — reason
+
+## Non-Functional Requirements
+- Performance: [metric with number]
+- Security: [constraint]
+- Reliability: [constraint]
+> Omit NFRs only for pure docs/markdown issues with zero runtime behavior.
+
+## Files to Modify
+- `path/to/file` — what changes
+```
+
 ## What NOT to do
 
 - Never commit directly to `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ When writing or rewriting an issue body during detailing, include ALL sections b
 - Performance: [metric with number]
 - Security: [constraint]
 - Reliability: [constraint]
-> Omit NFRs only for pure docs/markdown issues with zero runtime behavior.
+> For pure docs/markdown issues with zero runtime behavior, include the NFRs section and state "N/A".
 
 ## Files to Modify
 - `path/to/file` — what changes

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -157,7 +157,7 @@ When asked to work on a feature, you will:
 - Stop and wait for the human PM's explicit approval (Gate 1).
 
 ### 2. Creating the Spec
-Once approved, detail the solution directly into the GitHub Issue body. Always rewrite the full issue body — never append only ACs to existing text. Use this format:
+Once approved, detail the solution directly into the GitHub Issue body. Always rewrite the full issue body — never append only ACs to existing text. Include ALL sections below. Omitting any section blocks `stage:approval`. Use this format:
 
 ```
 ## Problem
@@ -186,7 +186,7 @@ Once approved, detail the solution directly into the GitHub Issue body. Always r
 - Performance: [metric with number]
 - Security: [constraint]
 - Reliability: [constraint]
-> Omit NFRs only for pure docs/markdown issues with zero runtime behavior.
+> For pure docs/markdown issues with zero runtime behavior, include the NFRs section and state "N/A".
 
 ## Files to Modify
 - `path/to/file` — what changes

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -157,18 +157,39 @@ When asked to work on a feature, you will:
 - Stop and wait for the human PM's explicit approval (Gate 1).
 
 ### 2. Creating the Spec
-Once approved, you will detail the solution directly into the GitHub Issue body. Focus on precise Acceptance Criteria.
-**IMPORTANT:** You must always rewrite the full issue body to include both the user story and the Acceptance Criteria. Do not simply append the ACs to the existing text. Use this format:
+Once approved, detail the solution directly into the GitHub Issue body. Always rewrite the full issue body — never append only ACs to existing text. Use this format:
 
 ```
-**As** [user],
-**I want** [action],
-**so that** [benefit].
+## Problem
+[1-3 sentences. What fails. Who affected. Measured impact.]
 
----
+## Sprint Goal / Success Metrics
+| Metric | Baseline | Target | When |
+|--------|----------|--------|------|
+
+## Solution
+[Behavioral description of what is built. No implementation details.]
 
 ## Acceptance Criteria
-...
+**AC1 — [name]**
+- Given [precondition]
+- When [action]
+- Then [outcome]
+
+## Edge Cases
+- EC1: [condition] → [expected behavior]
+
+## Out of Scope
+- [item] — reason
+
+## Non-Functional Requirements
+- Performance: [metric with number]
+- Security: [constraint]
+- Reliability: [constraint]
+> Omit NFRs only for pure docs/markdown issues with zero runtime behavior.
+
+## Files to Modify
+- `path/to/file` — what changes
 ```
 
 ### 3. Handoff

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -39,7 +39,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 7. Run typecheck (if applicable): `{{TYPECHECK_COMMAND}}`
 8. Create a Pull Request with `Closes #N` in the body — automation moves the board.
 
-### Spec Format
+## Spec Format
 
 When writing or rewriting an issue body during detailing, include ALL sections below. Omitting any section blocks `stage:approval`.
 
@@ -70,7 +70,7 @@ When writing or rewriting an issue body during detailing, include ALL sections b
 - Performance: [metric with number]
 - Security: [constraint]
 - Reliability: [constraint]
-> Omit NFRs only for pure docs/markdown issues with zero runtime behavior.
+> For pure docs/markdown issues with zero runtime behavior, include the NFRs section and state "N/A".
 
 ## Files to Modify
 - `path/to/file` — what changes

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -39,29 +39,41 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 7. Run typecheck (if applicable): `{{TYPECHECK_COMMAND}}`
 8. Create a Pull Request with `Closes #N` in the body — automation moves the board.
 
-### Spec format (Upstream Agents)
+### Spec Format
 
-When detailing a solution in an issue body, you must **always** include both the user story and the acceptance criteria. Never append only the ACs to an existing text; rewrite the full issue body in this standard format:
+When writing or rewriting an issue body during detailing, include ALL sections below. Omitting any section blocks `stage:approval`.
 
 ```
-**As** [user],
-**I want** [action],
-**so that** [benefit].
+## Problem
+[1-3 sentences. What fails. Who affected. Measured impact.]
 
----
+## Sprint Goal / Success Metrics
+| Metric | Baseline | Target | When |
+|--------|----------|--------|------|
+
+## Solution
+[Behavioral description of what is built. No implementation details.]
 
 ## Acceptance Criteria
+**AC1 — [name]**
+- Given [precondition]
+- When [action]
+- Then [outcome]
 
-**AC1 — ...**
-- Given ...
-- When ...
-- Then ...
+## Edge Cases
+- EC1: [condition] → [expected behavior]
 
-**AC2 — ...**
-...
+## Out of Scope
+- [item] — reason
 
-## Files to modify
-- `path/to/file.ts` — what changes
+## Non-Functional Requirements
+- Performance: [metric with number]
+- Security: [constraint]
+- Reliability: [constraint]
+> Omit NFRs only for pure docs/markdown issues with zero runtime behavior.
+
+## Files to Modify
+- `path/to/file` — what changes
 ```
 
 ## Stage Transition Rules (non-negotiable)


### PR DESCRIPTION
## Summary

- Adds `## Spec Format` section to root `AGENTS.md` with 7-section mandatory format
- Replaces user story wrapper (`As [user], I want...`) with Problem-first format in `templates/AGENTS.md`
- Updates `adapters/claude-code/skill.md` spec creation section with same format
- New mandatory sections: Problem, Sprint Goal/Metrics, Solution, ACs (Given/When/Then), Edge Cases, Out of Scope, NFRs

## Test plan

- [ ] Read root `AGENTS.md` — verify `## Spec Format` section present after `## Mandatory Workflow`
- [ ] Read `templates/AGENTS.md` — verify user story wrapper replaced by 7-section format
- [ ] Read `adapters/claude-code/skill.md` — verify Section 2 uses new format
- [ ] Confirm no `{{PLACEHOLDER}}` removed from `templates/AGENTS.md`

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)