### PR TITLE
feat(agents): add pre-spec'd issue exception to skip intermediate stages

### DIFF
--- a/.agentic-pdlc/templates/AGENTS.md
+++ b/.agentic-pdlc/templates/AGENTS.md
@@ -30,7 +30,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 ## Mandatory Workflow
 
 0. **Identity**: Always prefix your GitHub comments with `🤖 **Agent:** ` to distinguish yourself.
-1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`).
+1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`). **Exception — pre-spec'd issue**: if the issue body already contains all required spec sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`, `## Out of Scope`, `## Files to Modify`) — all present and non-empty — apply `stage:approval` directly in a single call instead, skipping `stage:brainstorming` and `stage:detailing`.
 2. Read the issue entirely — understand its type (US/BUG/TASK/SPIKE) and the Acceptance Criteria.
 3. Read `docs/pdlc.md` — understand the PDLC and the Definition of Done in this project.
 4. Read all files mentioned in the issue's technical context.
@@ -82,6 +82,13 @@ spec for human review. Adding them manually triggers irreversible automation
 
 Each stage transition requires a fresh explicit signal from the user in the same
 session where the transition happens. These rules have no exceptions.
+
+**Pre-spec'd exception**: if the issue body already contains all required spec
+sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`,
+`## Out of Scope`, `## Files to Modify`) — all present and non-empty — apply
+`stage:approval` directly in a single `gh issue edit` call, skipping
+`stage:brainstorming` and `stage:detailing`. One label event eliminates the
+race condition that causes the project board to land on the wrong column.
 
 ## What NOT to do
 

--- a/.agentic-pdlc/templates/AGENTS.md
+++ b/.agentic-pdlc/templates/AGENTS.md
@@ -74,19 +74,22 @@ MUST NOT add `stage:detailing` label until the user has explicitly selected
 an approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
-MUST NOT add `spec:approved`, `stage:development`, or manually add
-`stage:approval` — these represent final human approval or the result of it.
-`stage:approval` is only set by system automation after you provide a complete
-spec for human review. Adding them manually triggers irreversible automation
-(Jules dispatch, board move).
+MUST NOT add `spec:approved` or `stage:development` — these represent final
+human approval or automation output. Adding them manually triggers irreversible
+automation (Jules dispatch, board move).
+
+MUST NOT manually add `stage:approval` except via the pre-spec'd exception
+below. In the standard flow, `stage:approval` is set after you write a complete
+spec and the user confirms; it is not applied before the spec exists.
 
 Each stage transition requires a fresh explicit signal from the user in the same
-session where the transition happens. These rules have no exceptions.
+session where the transition happens. The pre-spec'd exception is the only
+deviation from this rule.
 
-**Pre-spec'd exception**: if the issue body already contains all required spec
-sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`,
-`## Out of Scope`, `## Files to Modify`) — all present and non-empty — apply
-`stage:approval` directly in a single `gh issue edit` call, skipping
+**Pre-spec'd exception**: if the issue body already contains a complete spec
+per the format above — user story (`**As**`/`**I want**`/`**so that**`),
+`## Acceptance Criteria`, and `## Files to modify` — all present and non-empty —
+apply `stage:approval` directly in a single `gh issue edit` call, skipping
 `stage:brainstorming` and `stage:detailing`. One label event eliminates the
 race condition that causes the project board to land on the wrong column.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 ## Mandatory Workflow
 
 0. **Identity**: Always prefix your GitHub comments with `🤖 **Agent:** ` to distinguish yourself.
-1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`).
+1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`). **Exception — pre-spec'd issue**: if the issue body already contains all required spec sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`, `## Out of Scope`, `## Files to Modify`) — all present and non-empty — apply `stage:approval` directly in a single call instead, skipping `stage:brainstorming` and `stage:detailing`.
 2. Read the issue entirely — understand its type (US/BUG/TASK/SPIKE) and the Acceptance Criteria.
 3. Read `docs/pdlc.md` — understand the PDLC and the Definition of Done in this project.
 4. Read all files mentioned in the issue's technical context.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -30,7 +30,7 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 ## Mandatory Workflow
 
 0. **Identity**: Always prefix your GitHub comments with `🤖 **Agent:** ` to distinguish yourself.
-1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`).
+1. **Initial State**: When beginning work on a new issue, your very first action must be to apply the `stage:brainstorming` label using the GitHub CLI (`gh issue edit <N> --add-label "stage:brainstorming"`). **Exception — pre-spec'd issue**: if the issue body already contains all required spec sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`, `## Out of Scope`, `## Files to Modify`) — all present and non-empty — apply `stage:approval` directly in a single call instead, skipping `stage:brainstorming` and `stage:detailing`.
 2. Read the issue entirely — understand its type (US/BUG/TASK/SPIKE) and the Acceptance Criteria.
 3. Read `docs/pdlc.md` — understand the PDLC and the Definition of Done in this project.
 4. Read all files mentioned in the issue's technical context.
@@ -95,6 +95,13 @@ spec for human review. Adding them manually triggers irreversible automation
 Each stage transition requires a fresh explicit signal from the user in the same
 session where the transition happens. These rules have no exceptions.
 
+**Pre-spec'd exception**: if the issue body already contains all required spec
+sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`,
+`## Out of Scope`, `## Files to Modify`) — all present and non-empty — apply
+`stage:approval` directly in a single `gh issue edit` call, skipping
+`stage:brainstorming` and `stage:detailing`. One label event eliminates the
+race condition that causes the project board to land on the wrong column.
+
 ## Pipeline Updates
 
 To add or configure optional agents (Jules, QA Agent, Sentinel) at any time:
@@ -115,7 +122,7 @@ Run this when the user says anything like "update the pipeline", "update the boa
   - `spec:approved`: triggers Jules dispatch + board move to Development.
   - `qa:approved`: triggers board move to Code Review.
   - `qa:needs-work`: signals the PR requires changes and halts the flow.
-- Never add or remove stage:* labels manually, except for stage:brainstorming as the initial label when starting work. All other stage transitions are owned by GitHub Actions automation and the PM.
+- Never add or remove stage:* labels manually, except: `stage:brainstorming` as the initial label when starting work, or `stage:approval` directly when applying the pre-spec'd exception. All other stage transitions are owned by GitHub Actions automation and the PM.
 {{EXTRA_DONT}}
 
 ## Project Standards

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -86,14 +86,17 @@ MUST NOT add `stage:detailing` label until the user has explicitly selected
 an approach in the current conversation turn. Work done in a prior
 planning session does NOT count as confirmation.
 
-MUST NOT add `spec:approved`, `stage:development`, or manually add
-`stage:approval` — these represent final human approval or the result of it.
-`stage:approval` is only set by system automation after you provide a complete
-spec for human review. Adding them manually triggers irreversible automation
-(Jules dispatch, board move).
+MUST NOT add `spec:approved` or `stage:development` — these represent final
+human approval or automation output. Adding them manually triggers irreversible
+automation (Jules dispatch, board move).
+
+MUST NOT manually add `stage:approval` except via the pre-spec'd exception
+below. In the standard flow, `stage:approval` is set after you write a complete
+spec and the user confirms; it is not applied before the spec exists.
 
 Each stage transition requires a fresh explicit signal from the user in the same
-session where the transition happens. These rules have no exceptions.
+session where the transition happens. The pre-spec'd exception is the only
+deviation from this rule.
 
 **Pre-spec'd exception**: if the issue body already contains all required spec
 sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`,


### PR DESCRIPTION
## Summary

- Adds **pre-spec'd exception** to all three `AGENTS.md` files (root, `templates/`, `.agentic-pdlc/templates/`)
- When an issue body already contains all required spec sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`, `## Out of Scope`, `## Files to Modify`) — all present and non-empty — agent applies `stage:approval` directly in a single call, skipping `stage:brainstorming` and `stage:detailing`
- One label event → no multi-event race condition → board always lands on correct column
- `templates/AGENTS.md` also updates the "What NOT to do" list to explicitly allow `stage:approval` under the exception

## Test plan

- [ ] Read updated `AGENTS.md` — exception rule present in step 1 of Mandatory Workflow
- [ ] Read updated `templates/AGENTS.md` — exception in step 1, Stage Transition Rules, and What NOT to do
- [ ] Read updated `.agentic-pdlc/templates/AGENTS.md` — exception in step 1 and Stage Transition Rules
- [ ] Verify all `{{SCREAMING_SNAKE_CASE}}` placeholders remain intact in both template files

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)