### PR TITLE
fix: implement human-approved → qa:approved automation (issue #116)

### DIFF
--- a/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/.agentic-pdlc/templates/.github/workflows/pdlc-stage-gate.yml
@@ -37,12 +37,12 @@ jobs:
 
           for NUM in $ISSUE_NUMS; do
             LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development"; then
+            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development" || echo "$LABELS" | grep -qw "stage:testing"; then
               echo "✅ Issue #$NUM approved"
             else
               STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
               echo "❌ Issue #$NUM missing approval (current: $STAGE)"
-              echo "   Required: stage:approval OR spec:approved OR stage:development label on the issue."
+              echo "   Required: stage:approval OR spec:approved OR stage:development OR stage:testing label on the issue."
               echo "   Emergency bypass: add 'hotfix' label to this PR."
               exit 1
             fi

--- a/.agentic-pdlc/templates/.github/workflows/project-automation.yml
+++ b/.agentic-pdlc/templates/.github/workflows/project-automation.yml
@@ -83,6 +83,42 @@ jobs:
             await moveItem(node_id, targetStatusId);
             console.log(`Issue #${number} moved to ${stageName}`);
 
+  # human-approved on issue → qa:approved on linked open PRs
+  handle-human-approved:
+    name: human-approved → qa:approved on linked PRs
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'human-approved'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add qa:approved to linked open PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const pattern = new RegExp(`(?:Closes?|Fixes?|Resolves?)\\s+#${issueNumber}\\b`, 'i');
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+
+            const linked = prs.filter(pr => pattern.test(pr.body ?? ''));
+
+            if (linked.length === 0) {
+              console.log(`No open PRs linking issue #${issueNumber}. Exiting.`);
+              return;
+            }
+
+            for (const pr of linked) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: ['qa:approved']
+              }).catch(() => {});
+              console.log(`PR #${pr.number} → qa:approved`);
+            }
+
   # OPTIONAL: Uncomment to enable architecture-violation → Idea
   # move-violation-to-board:
   #   name: architecture-violation → 💡 Idea

--- a/.github/workflows/pdlc-stage-gate.yml
+++ b/.github/workflows/pdlc-stage-gate.yml
@@ -37,12 +37,12 @@ jobs:
 
           for NUM in $ISSUE_NUMS; do
             LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development"; then
+            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development" || echo "$LABELS" | grep -qw "stage:testing"; then
               echo "✅ Issue #$NUM approved"
             else
               STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
               echo "❌ Issue #$NUM missing approval (current: $STAGE)"
-              echo "   Required: stage:approval OR spec:approved OR stage:development label on the issue."
+              echo "   Required: stage:approval OR spec:approved OR stage:development OR stage:testing label on the issue."
               echo "   Emergency bypass: add 'hotfix' label to this PR."
               exit 1
             fi

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -83,6 +83,42 @@ jobs:
             await moveItem(node_id, targetStatusId);
             console.log(`Issue #${number} moved to ${stageName}`);
 
+  # human-approved on issue → qa:approved on linked open PRs
+  handle-human-approved:
+    name: human-approved → qa:approved on linked PRs
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'human-approved'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add qa:approved to linked open PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const pattern = new RegExp(`(?:Closes?|Fixes?|Resolves?)\\s+#${issueNumber}\\b`, 'i');
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+
+            const linked = prs.filter(pr => pattern.test(pr.body ?? ''));
+
+            if (linked.length === 0) {
+              console.log(`No open PRs linking issue #${issueNumber}. Exiting.`);
+              return;
+            }
+
+            for (const pr of linked) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: ['qa:approved']
+              }).catch(() => {});
+              console.log(`PR #${pr.number} → qa:approved`);
+            }
+
   # OPTIONAL: Uncomment to enable architecture-violation → Idea
   # move-violation-to-board:
   #   name: architecture-violation → 💡 Idea

--- a/docs/pdlc.md
+++ b/docs/pdlc.md
@@ -103,7 +103,7 @@ Agents MUST NOT skip any stage. The ONLY authorized bypasses are:
 
 | Mechanism | Who authorizes | What it bypasses |
 |---|---|---|
-| `human-approved` label on issue | PM (human) only | All stage gates |
+| `human-approved` label on issue | PM (human) only | All stage gates — automation adds `qa:approved` to linked PRs, moving card to Code Review / PR. `pdlc-stage-gate` accepts `stage:testing` as a valid post-gate state. |
 | Branch prefix `hotfix/` | PM (human) only | PR gate only |
 
 Agents MUST NOT self-authorize a bypass. Stop and ask the PM explicitly.

--- a/templates/.github/workflows/pdlc-stage-gate.yml
+++ b/templates/.github/workflows/pdlc-stage-gate.yml
@@ -37,12 +37,12 @@ jobs:
 
           for NUM in $ISSUE_NUMS; do
             LABELS=$(gh issue view "$NUM" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development"; then
+            if echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development" || echo "$LABELS" | grep -qw "stage:testing"; then
               echo "✅ Issue #$NUM approved"
             else
               STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
               echo "❌ Issue #$NUM missing approval (current: $STAGE)"
-              echo "   Required: stage:approval OR spec:approved OR stage:development label on the issue."
+              echo "   Required: stage:approval OR spec:approved OR stage:development OR stage:testing label on the issue."
               echo "   Emergency bypass: add 'hotfix' label to this PR."
               exit 1
             fi

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -109,6 +109,42 @@ jobs:
             await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'stage:detailing' }).catch(() => {});
             console.log(`Issue #${issue_number} auto-moved to stage:approval`);
 
+  # human-approved on issue → qa:approved on linked open PRs
+  handle-human-approved:
+    name: human-approved → qa:approved on linked PRs
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'human-approved'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add qa:approved to linked open PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const pattern = new RegExp(`(?:Closes?|Fixes?|Resolves?)\\s+#${issueNumber}\\b`, 'i');
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+
+            const linked = prs.filter(pr => pattern.test(pr.body ?? ''));
+
+            if (linked.length === 0) {
+              console.log(`No open PRs linking issue #${issueNumber}. Exiting.`);
+              return;
+            }
+
+            for (const pr of linked) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: ['qa:approved']
+              }).catch(() => {});
+              console.log(`PR #${pr.number} → qa:approved`);
+            }
+
   # OPTIONAL: Uncomment to enable architecture-violation → Idea
   # move-violation-to-board:
   #   name: architecture-violation → 💡 Idea


### PR DESCRIPTION
## Summary

- Add `handle-human-approved` job to `project-automation.yml`: when PM adds `human-approved` to an issue, finds open PRs linking that issue via `Closes/Fixes/Resolves #N` and adds `qa:approved` to them — triggering the existing `move-card-on-qa-pass` to move the card to Code Review / PR
- Fix `pdlc-stage-gate.yml`: accept `stage:testing` as valid post-gate label (prevents false CI failures when `qa:approved` is added to a PR whose linked issue is in `stage:testing`)
- Both fixes applied in all 3 workflow locations (live + 2 template dirs)
- Update `docs/pdlc.md` to document the automation behavior

## Test Plan

- [ ] Add `human-approved` to an issue that has an open PR with `Closes #N` in body → verify `qa:approved` appears on that PR
- [ ] Add `human-approved` to an issue with no linked open PR → verify job exits cleanly (green run, log says "No open PRs linking issue #N. Exiting.")
- [ ] Verify CI (`pdlc-stage-gate`) passes on a PR whose linked issue has `stage:testing`

Closes #116