### PR TITLE
fix(workflows): remove agent:working label

### DIFF
--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -44,7 +44,7 @@ jobs:
               owner,
               repo,
               issue_number,
-              labels: ['stage:development', 'agent:working']
+              labels: ['stage:development']
             });
 
       - name: Move board card to Development

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -185,7 +185,7 @@ jobs:
                 });
             };
 
-            const stageLabelsToRemove = ['stage:development', 'stage:brainstorming', 'stage:detailing', 'jules', 'agent:working'];
+            const stageLabelsToRemove = ['stage:development', 'stage:brainstorming', 'stage:detailing', 'jules'];
 
             if (linkedIssues.length > 0) {
               for (const n of linkedIssues) {
@@ -339,7 +339,7 @@ jobs:
             const toRemove = [
               'stage:brainstorming', 'stage:detailing',
               'stage:approval', 'stage:development', 'stage:testing',
-              'agent:working', 'qa:needs-work', 'pr:in-review', 'jules'
+              'qa:needs-work', 'pr:in-review', 'jules'
             ];
             for (const label of toRemove) {
               await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label }).catch(() => {});

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -45,7 +45,7 @@ jobs:
               owner,
               repo,
               issue_number,
-              labels: ['stage:development', 'agent:working']
+              labels: ['stage:development']
             });
 
       - name: Add agent label via PAT

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -353,7 +353,7 @@ jobs:
             const toRemove = [
               'stage:brainstorming', 'stage:detailing',
               'stage:approval', 'stage:development', 'stage:testing',
-              'agent:working', 'qa:needs-work', 'pr:in-review', 'jules'
+              'qa:needs-work', 'pr:in-review', 'jules'
             ];
             for (const label of toRemove) {
               await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label }).catch(() => {});


### PR DESCRIPTION
## Summary

- Removes `agent:working` from all add/remove lists across 4 workflow files
- Label had no functional role — added on `stage:development` entry, removed on close/merge, never read as trigger or condition
- `.agentic-pdlc/templates` was clean (no occurrences)

## Files changed

- `.github/workflows/agent-trigger.yml`
- `.github/workflows/project-automation.yml`
- `templates/.github/workflows/agent-trigger.yml`
- `templates/.github/workflows/project-automation.yml`

## Test plan

- [ ] `grep -r "agent:working" .github/ templates/ .agentic-pdlc/` returns no results ✅ (verified pre-commit)
- [ ] Workflows still add `stage:development` on trigger
- [ ] Cleanup steps still remove all other labels in scope

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)