### PR TITLE
fix(templates): sync PROJECT_PAT → PROJECT_TOKEN across all workflow templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,4 @@ When writing or rewriting an issue body during detailing, include ALL sections b
 - **Lint/Types:** `echo "No tests/build needed."`
 - **Typecheck:** `echo "No typecheck needed."`
 - **Build:** `echo "No tests/build needed."`
+- **Canonical secret name:** `PROJECT_TOKEN` (not `PROJECT_PAT`) — use this in all workflow files, both live and templates

--- a/templates/.github/workflows/add-to-board.yml
+++ b/templates/.github/workflows/add-to-board.yml
@@ -14,13 +14,13 @@ jobs:
     name: Auto-add new issue to board
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Add issue to project board
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const nodeId = context.payload.issue.node_id;
             const number = context.payload.issue.number;

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       contents: read
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
       PROJECT_ID: "{{PROJECT_ID}}"
       STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
       STATUS_DEVELOPMENT: "{{ID_DEVELOPMENT}}"
@@ -49,10 +49,10 @@ jobs:
             });
 
       - name: Add agent label via PAT
-        if: ${{ env.PROJECT_PAT != '' && !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
+        if: ${{ env.PROJECT_TOKEN != '' && !contains('{{IMPLEMENTATION_AGENT_LABEL}}', '{{') }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -62,11 +62,11 @@ jobs:
             });
 
       - name: Move board card to Development
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         continue-on-error: true
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const nodeId = context.payload.issue.node_id;
             const number = context.payload.issue.number;

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -27,13 +27,13 @@ jobs:
     if: github.event_name == 'issues' && github.event.action == 'labeled'
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Detect Label and Move Issue
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const labelName = context.payload.label.name;
             let targetStatusId = null;
@@ -88,13 +88,13 @@ jobs:
       contains(github.event.issue.labels.*.name, 'stage:detailing')
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Check spec markers and swap labels
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const body = context.payload.issue.body ?? '';
             if (!body.includes('## Acceptance Criteria') || !body.includes('## Files to modify')) return;
@@ -149,10 +149,10 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Move issue to Idea
-  #       if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+  #       if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
   #       uses: actions/github-script@v8
   #       with:
-  #         github-token: ${{ env.PROJECT_PAT }}
+  #         github-token: ${{ env.PROJECT_TOKEN }}
   #         script: |
   #           const { issue: { number, node_id } } = context.payload;
   #           const { addProjectV2ItemById: { item } } = await github.graphql(`
@@ -176,13 +176,13 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Move linked issue to Testing
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
@@ -230,13 +230,13 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'qa:approved'
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Move linked issue to Code Review / PR
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
@@ -278,13 +278,13 @@ jobs:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Swap PR labels
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
@@ -297,13 +297,13 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Move issue to Production
-        if: ${{ env.PROJECT_PAT != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_PAT }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const { owner, repo } = context.repo;

--- a/templates/.github/workflows/qa-agent.yml
+++ b/templates/.github/workflows/qa-agent.yml
@@ -14,7 +14,7 @@ jobs:
     name: AC Coverage Verification (GitHub Models)
     runs-on: ubuntu-latest
     env:
-      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - uses: actions/checkout@v5.0.1
         with:
@@ -61,7 +61,7 @@ jobs:
             --max-time 30 || echo "API_ERROR")
 
           if [ "$RESPONSE" = "API_ERROR" ]; then
-            GH_TOKEN="$PROJECT_PAT" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=infra:qa-broken'
+            GH_TOKEN="$PROJECT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=infra:qa-broken'
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** Could not reach GitHub Models API. Manual review required."
             exit 1
           fi
@@ -70,17 +70,17 @@ jobs:
           EXPLANATION=$(echo "$RESPONSE" | python3 -c 'import json,sys; d=json.load(sys.stdin); t=d.get("choices",[{}])[0].get("message",{}).get("content","").strip(); lines=t.split("\n",1); print(lines[1].strip() if len(lines)>1 else "")')
 
           if echo "$VERDICT" | grep -q "^PASS"; then
-            GH_TOKEN="$PROJECT_PAT" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=qa:approved'
+            GH_TOKEN="$PROJECT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=qa:approved'
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** PASS
 
 ${EXPLANATION}"
           elif echo "$VERDICT" | grep -q "^FAIL"; then
-            GH_TOKEN="$PROJECT_PAT" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=qa:needs-work'
+            GH_TOKEN="$PROJECT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=qa:needs-work'
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** FAIL
 
 ${EXPLANATION}"
           else
-            GH_TOKEN="$PROJECT_PAT" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=infra:qa-broken'
+            GH_TOKEN="$PROJECT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=infra:qa-broken'
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** Could not parse GitHub Models response. Manual review required."
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Renamed all `PROJECT_PAT` occurrences to `PROJECT_TOKEN` across 4 template workflows (`qa-agent`, `agent-trigger`, `add-to-board`, `project-automation`) — including commented-out lines
- Added canonical secret name declaration to `AGENTS.md` to prevent future drift

## Test plan

- [ ] `grep -r PROJECT_PAT templates/` returns no matches
- [ ] `grep -r PROJECT_TOKEN templates/` matches all expected locations (same count as live workflows)
- [ ] `AGENTS.md` contains `PROJECT_TOKEN` under Project Standards

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)