### PR TITLE
fix(qa-gate): add human-approved bypass + document API_ERROR exit behavior

### DIFF
--- a/.github/workflows/qa-agent.yml
+++ b/.github/workflows/qa-agent.yml
@@ -66,6 +66,7 @@ jobs:
           if [ "$RESPONSE" = "API_ERROR" ]; then
             GH_TOKEN="$PROJECT_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --method POST -f 'labels[]=infra:qa-broken'
             gh pr comment "$PR_NUMBER" --body "🤖 **QA Agent:** Could not reach GitHub Models API. Manual review required."
+            # exit 1 marks this check as failed; qa-gate.yml enforces the merge block via infra:qa-broken label
             exit 1
           fi
 

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -27,6 +27,11 @@ jobs:
             exit 0
           fi
 
+          if echo "$PR_LABELS" | grep -qx "human-approved"; then
+            echo "✅ QA Gate: human-approved label — manual QA sign-off, bypassed."
+            exit 0
+          fi
+
           if echo "$PR_LABELS" | grep -qx "qa:approved"; then
             echo "✅ QA Gate: qa:approved — merge allowed."
             exit 0

--- a/templates/.github/workflows/qa-gate.yml
+++ b/templates/.github/workflows/qa-gate.yml
@@ -27,6 +27,11 @@ jobs:
             exit 0
           fi
 
+          if echo "$PR_LABELS" | grep -qx "human-approved"; then
+            echo "✅ QA Gate: human-approved label — manual QA sign-off, bypassed."
+            exit 0
+          fi
+
           if echo "$PR_LABELS" | grep -qx "qa:approved"; then
             echo "✅ QA Gate: qa:approved — merge allowed."
             exit 0


### PR DESCRIPTION
## Summary

- Add `human-approved` PR-label bypass to `qa-gate.yml` (after `hotfix` check, same pattern)
- Mirror identical change in `templates/.github/workflows/qa-gate.yml`
- Add inline comment in `qa-agent.yml` explaining `exit 1` on `API_ERROR` path

## Test plan

- [ ] PR with `human-approved` label → QA Gate passes
- [ ] PR with `hotfix` label → QA Gate still passes (no regression)
- [ ] PR with `qa:approved` label → QA Gate passes (no regression)
- [ ] PR with `qa:needs-work` → QA Gate still blocks (no regression)
- [ ] `templates/qa-gate.yml` identical to live `qa-gate.yml`
- [ ] `qa-agent.yml` API_ERROR block has inline comment

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)