### PR TITLE
fix(spec): require spec content in issue body, not file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ The PreToolUse hook will block `gh pr create` automatically if this rule is viol
 
 **Detailing is fully autonomous.** Write the complete spec, add it to the issue, advance to `stage:approval` — no confirmation needed. Then **stop and wait** for human to add `spec:approved` before any implementation.
 
+**Spec destination: the issue body.** Write spec content to the issue body using `gh issue edit <N> --body "..."` — not to a file. A file is acceptable as optional reference only. Automation checks the issue body for `## Acceptance Criteria` and `## Files to Modify` to advance the stage; content that exists only in a file is invisible to it.
+
 ## Stage Transition Rules (non-negotiable)
 
 MUST apply `stage:brainstorming` label immediately on starting work — before

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -47,6 +47,8 @@ Always start from the current `main` HEAD. Never work over stale snapshots.
 
 When writing or rewriting an issue body during detailing, include ALL sections below. Omitting any section blocks `stage:approval`.
 
+**Destination: the issue body.** Write spec content to the issue body using `gh issue edit <N> --body "..."` — not to a file. A file is acceptable as optional reference only. Automation checks the issue body for `## Acceptance Criteria` and `## Files to Modify` to advance the stage; content that exists only in a file is invisible to it.
+
 ```
 ## Problem
 [1-3 sentences. What fails. Who affected. Measured impact.]


### PR DESCRIPTION
## Summary

- Add **Destination: the issue body** rule to `templates/AGENTS.md` Spec Format section
- Add **Spec destination: the issue body** rule to root `CLAUDE.md` Human-in-the-Loop section
- Both rules state: write via `gh issue edit`, file is optional reference only, automation checks issue body not files

## Test plan

- [ ] Verify `templates/AGENTS.md` Spec Format section contains destination rule
- [ ] Verify `CLAUDE.md` contains spec destination rule under Human-in-the-Loop

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)