### PR TITLE
chore: remove cosmetic agent:working label and drop false stack claim (#155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # agentic-pdlc
 
-**What it is:** npm CLI (`npx create-agentic-pdlc`) that installs a PDLC workflow for AI agent projects. Stack: Markdown + GitHub Actions YAML only — never complex Node/Python/Bash scripts.
+**What it is:** npm CLI (`npx create-agentic-pdlc`) that installs a PDLC workflow for AI agent projects.
 
 **Workflow:** `stage:brainstorming` → `stage:detailing` → `spec:approved` → `stage:development` → PR → merge. Labels move the board automatically.
 


### PR DESCRIPTION
## Summary

- Deletes `agent:working` label from repo — no workflow reads or gates on it, pure noise
- Removes the stack constraint sentence from `CLAUDE.md` line 3 — claim was inaccurate (Python existed in `qa-agent.yml`) and became moot after 0.2 removed all complex workflows

## Test plan

- [ ] Confirm `agent:working` no longer appears in repo label list
- [ ] Confirm `CLAUDE.md` no longer contains the stack constraint sentence
- [ ] Confirm all workflows pass (no references to deleted label)

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)