### PR TITLE
feat(hook): harden stage-gate — fix label check + expand to Edit/Write tools

### DIFF
--- a/.agentic-pdlc/hooks/pdlc-stage-gate.sh
+++ b/.agentic-pdlc/hooks/pdlc-stage-gate.sh
@@ -3,8 +3,8 @@
 # Bypass: branch prefix hotfix/ skips all checks.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.command // ""' 2>/dev/null || echo "")
-FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // ""' 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | node -e "const d=JSON.parse(require('fs').readFileSync(0)); console.log(d.command || '')" 2>/dev/null || echo "")
+FILE_PATH=$(echo "$INPUT" | node -e "const d=JSON.parse(require('fs').readFileSync(0)); console.log(d.file_path || '')" 2>/dev/null || echo "")
 
 IS_PR_CREATE=false
 IS_FILE_EDIT=false
@@ -15,7 +15,7 @@ elif [ -n "$FILE_PATH" ]; then
   IS_FILE_EDIT=true
 fi
 
-if ! $IS_PR_CREATE && ! $IS_FILE_EDIT; then
+if [ "$IS_PR_CREATE" != "true" ] && [ "$IS_FILE_EDIT" != "true" ]; then
   exit 0
 fi
 
@@ -28,7 +28,7 @@ fi
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | head -1)
 
 if [ -z "$ISSUE_NUM" ]; then
-  if $IS_FILE_EDIT; then
+  if [ "$IS_FILE_EDIT" = "true" ]; then
     exit 0
   fi
   echo "❌ PDLC Stage Gate: Cannot determine issue from branch '$BRANCH'."
@@ -50,7 +50,7 @@ fi
 
 STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
 
-if $IS_PR_CREATE; then
+if [ "$IS_PR_CREATE" = "true" ]; then
   echo "❌ PDLC Stage Gate: PR creation blocked — issue #$ISSUE_NUM missing spec:approved."
   echo "   Current stage: $STAGE"
   echo "   Missing condition: spec:approved (set by PM after reviewing spec in issue body)"

--- a/.agentic-pdlc/hooks/pdlc-stage-gate.sh
+++ b/.agentic-pdlc/hooks/pdlc-stage-gate.sh
@@ -1,39 +1,66 @@
 #!/bin/bash
-# PDLC Stage Gate — blocks gh pr create without stage:approval on linked issue.
+# PDLC Stage Gate — blocks gh pr create and file edits without spec:approved on linked issue.
 # Bypass: branch prefix hotfix/ skips all checks.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | node -e "const d=JSON.parse(require('fs').readFileSync(0)); console.log(d.command || '')" 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | jq -r '.command // ""' 2>/dev/null || echo "")
+FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // ""' 2>/dev/null || echo "")
 
-if ! echo "$COMMAND" | grep -q "gh pr create"; then
+IS_PR_CREATE=false
+IS_FILE_EDIT=false
+
+if echo "$COMMAND" | grep -q "gh pr create"; then
+  IS_PR_CREATE=true
+elif [ -n "$FILE_PATH" ]; then
+  IS_FILE_EDIT=true
+fi
+
+if ! $IS_PR_CREATE && ! $IS_FILE_EDIT; then
   exit 0
 fi
 
 BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 
 if echo "$BRANCH" | grep -qE "^hotfix/"; then
-  echo "✅ PDLC: Hotfix branch — stage gate bypassed."
   exit 0
 fi
 
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | head -1)
 
 if [ -z "$ISSUE_NUM" ]; then
+  if $IS_FILE_EDIT; then
+    exit 0
+  fi
   echo "❌ PDLC Stage Gate: Cannot determine issue from branch '$BRANCH'."
   echo "   Use: feat/<issue-number>-<description> or hotfix/<issue-number>-<description>"
   exit 1
 fi
 
-LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$LABELS" ]; then
+  echo "❌ PDLC Stage Gate: Could not fetch labels for issue #$ISSUE_NUM."
+  echo "   Missing condition: spec:approved"
+  echo "   Next step: verify gh auth and issue number, then have PM add spec:approved."
+  exit 1
+fi
 
-if echo "$LABELS" | grep -qw "stage:approval"; then
-  echo "✅ PDLC: Issue #$ISSUE_NUM approved — gate passed."
+if echo "$LABELS" | grep -qw "spec:approved"; then
   exit 0
 fi
 
 STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
-echo "❌ PDLC Stage Gate: Issue #$ISSUE_NUM is not approved."
-echo "   Current stage: $STAGE"
-echo "   Required: stage:approval label on the issue."
-echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
+
+if $IS_PR_CREATE; then
+  echo "❌ PDLC Stage Gate: PR creation blocked — issue #$ISSUE_NUM missing spec:approved."
+  echo "   Current stage: $STAGE"
+  echo "   Missing condition: spec:approved (set by PM after reviewing spec in issue body)"
+  echo "   Next step: complete spec → stage:approval → wait for PM to add spec:approved."
+  echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
+else
+  echo "❌ PDLC Stage Gate: File edit blocked — issue #$ISSUE_NUM missing spec:approved."
+  echo "   Current stage: $STAGE"
+  echo "   Missing condition: spec:approved (set by PM after reviewing spec in issue body)"
+  echo "   Next step: complete spec → stage:approval → wait for PM to add spec:approved."
+  echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
+fi
 exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,24 @@
             "command": "bash .agentic-pdlc/hooks/pdlc-stage-gate.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .agentic-pdlc/hooks/pdlc-stage-gate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .agentic-pdlc/hooks/pdlc-stage-gate.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- **Fixes critical label bug**: hook was checking `stage:approval` but the correct gate label is `spec:approved` — agents could create PRs immediately after spec was written, without PM review
- **Expands tool coverage**: adds `Edit` and `Write` matchers to `settings.json`; file edits are now blocked without `spec:approved` (not just `gh pr create`)
- **Fail-closed**: `gh` label fetch failure now blocks rather than allows
- **Clear error messages**: each blocking path names the action blocked, current stage, missing condition, next step, and emergency bypass

## Test plan

- [x] Non-PR bash commands pass through (exit 0)
- [x] `gh pr create` on approved issue (`spec:approved`) passes (exit 0)
- [x] `Edit`/`Write` tool on approved issue passes (exit 0)
- [x] `gh pr create` on unapproved issue blocked — message names `spec:approved` + current stage + next step (exit 1)
- [x] `Edit` tool on unapproved issue blocked — distinct "File edit blocked" message (exit 1)
- [x] `hotfix/` branch bypasses both PR and file-edit gate (exit 0)
- [x] Branch with no issue number: PR gate blocks, file-edit gate allows (EC1)

Closes #156

🤖 **Agent:** Generated with [Claude Code](https://claude.com/claude-code)