### PR TITLE
feat: add CodeRabbit config to replace Gemini Code Assist

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,22 @@
+language: "en-US"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >
+        Pay close attention to GitHub Actions syntax correctness, trigger
+        semantics (push/pull_request/workflow_run events and their filters),
+        expression syntax (${{ }}), and shell quoting in run steps.
+        Flag any logic that could cause silent failures or unintended trigger
+        behavior.
+  review_status: true
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary

- Adds `.coderabbit.yaml` to configure CodeRabbit as advisory code reviewer replacing Gemini Code Assist (sunsets July 17, 2026)
- `chill` profile + `request_changes_workflow: false` ensures advisory-only, never blocks merge
- Path instructions for `.github/workflows/**` preserve Gemini's YAML/Actions awareness
- GitHub App installation must be done separately via GitHub Marketplace before June 18

## Notes on config fields beyond spec

Three fields added beyond the minimum spec — all intentional:
- `high_level_summary: true` — useful PR summary in review
- `poem: false` — suppresses CodeRabbit's novelty poem feature, reduces noise
- `review_status: true` — informational timeline status only, not a blocking check

## Test plan

- [ ] Install CodeRabbit GitHub App on repo before June 18, 2026
- [ ] Open a test PR and confirm CodeRabbit posts advisory inline comments
- [ ] Confirm no blocking status check appears in PR checks
- [ ] Confirm CodeRabbit does not add labels or block merge

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)