### PR TITLE
refactor(board): resolve columns by name, remove all hardcoded Project IDs

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -8,6 +8,8 @@ jobs:
   resolve-ids:
     name: Resolve Board Column IDs
     runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     outputs:
       project_id: ${{ steps.resolve.outputs.project_id }}
       status_field_id: ${{ steps.resolve.outputs.status_field_id }}
@@ -15,10 +17,10 @@ jobs:
     steps:
       - name: Resolve column IDs by name
         id: resolve
-        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const projectId = '${{ vars.PROJECT_ID }}';
             if (!projectId || projectId === '{{PROJECT_ID}}') {

--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -4,20 +4,64 @@ on:
   issues:
     types: [opened]
 
-env:
-  PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
-  STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
-  STATUS_IDEA: "bb6e5a20"
-
 jobs:
+  resolve-ids:
+    name: Resolve Board Column IDs
+    runs-on: ubuntu-latest
+    outputs:
+      project_id: ${{ steps.resolve.outputs.project_id }}
+      status_field_id: ${{ steps.resolve.outputs.status_field_id }}
+      status_idea: ${{ steps.resolve.outputs.status_idea }}
+    steps:
+      - name: Resolve column IDs by name
+        id: resolve
+        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectId = '${{ vars.PROJECT_ID }}';
+            if (!projectId || projectId === '{{PROJECT_ID}}') {
+              core.warning('vars.PROJECT_ID not set — board features disabled');
+              return;
+            }
+            const { node } = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on ProjectV2 {
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { id: projectId });
+            const statusField = node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) { core.setFailed('Status field not found on board'); return; }
+            const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            core.setOutput('project_id', projectId);
+            core.setOutput('status_field_id', statusField.id);
+            core.setOutput('status_idea', opt('Idea'));
+            console.log('✅ Board IDs resolved by name');
+
   add-to-board:
     name: Auto-add new issue to board
+    needs: [resolve-ids]
     runs-on: ubuntu-latest
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_IDEA: ${{ needs.resolve-ids.outputs.status_idea }}
     steps:
       - name: Add issue to project board
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}

--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Resolve column IDs by name
         id: resolve
         if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Add issue to project board
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Resolve column IDs by name
         id: resolve
         if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -69,7 +69,7 @@ jobs:
       STATUS_DEVELOPMENT: ${{ needs.resolve-ids.outputs.status_development }}
     steps:
       - name: Swap labels — stage:approval → stage:development
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -85,7 +85,7 @@ jobs:
       - name: Move board card to Development
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -113,7 +113,7 @@ jobs:
       contents: read
     steps:
       - name: Comment on issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -7,9 +7,54 @@ on:
     types: [labeled]
 
 jobs:
+  resolve-ids:
+    name: Resolve Board Column IDs
+    runs-on: ubuntu-latest
+    outputs:
+      project_id: ${{ steps.resolve.outputs.project_id }}
+      status_field_id: ${{ steps.resolve.outputs.status_field_id }}
+      status_development: ${{ steps.resolve.outputs.status_development }}
+    steps:
+      - name: Resolve column IDs by name
+        id: resolve
+        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectId = '${{ vars.PROJECT_ID }}';
+            if (!projectId || projectId === '{{PROJECT_ID}}') {
+              core.warning('vars.PROJECT_ID not set — board features disabled');
+              return;
+            }
+            const { node } = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on ProjectV2 {
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { id: projectId });
+            const statusField = node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) { core.setFailed('Status field not found on board'); return; }
+            const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            core.setOutput('project_id', projectId);
+            core.setOutput('status_field_id', statusField.id);
+            core.setOutput('status_development', opt('Development'));
+            console.log('✅ Board IDs resolved by name');
+
   trigger-implementation-agent:
     name: Advance issue to stage:development
-    # Runs only when spec:approved is added
+    needs: [resolve-ids]
     if: github.event.label.name == 'spec:approved'
     runs-on: ubuntu-latest
     permissions:
@@ -17,9 +62,9 @@ jobs:
       contents: read
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-      PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
-      STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
-      STATUS_DEVELOPMENT: "2c9e78e6"
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_DEVELOPMENT: ${{ needs.resolve-ids.outputs.status_development }}
     steps:
       - name: Swap labels — stage:approval → stage:development
         uses: actions/github-script@v8
@@ -28,27 +73,15 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
-
             try {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number,
-                name: 'stage:approval'
-              });
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'stage:approval' });
             } catch (error) {
               console.log('Label stage:approval not found or could not be removed');
             }
-
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number,
-              labels: ['stage:development']
-            });
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['stage:development'] });
 
       - name: Move board card to Development
-        if: ${{ env.PROJECT_TOKEN != '' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         continue-on-error: true
         uses: actions/github-script@v8
         with:
@@ -71,7 +104,6 @@ jobs:
 
   trigger-agent-on-violation:
     name: Flag architecture violation
-    # Runs when architecture-violation is added (Sentinel flow)
     if: github.event.label.name == 'architecture-violation'
     runs-on: ubuntu-latest
     permissions:
@@ -84,7 +116,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issueNumber = context.payload.issue.number;
-
             const body = [
               `⚠️ **Architecture violation detected.** Please fix the issue described above.`,
               '',
@@ -96,7 +127,6 @@ jobs:
               '- Fix only what the violation points out — do not refactor unrelated code',
               `- Include \`Closes #${issueNumber}\` in the PR body`,
             ].join('\n');
-
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -10,6 +10,8 @@ jobs:
   resolve-ids:
     name: Resolve Board Column IDs
     runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     outputs:
       project_id: ${{ steps.resolve.outputs.project_id }}
       status_field_id: ${{ steps.resolve.outputs.status_field_id }}
@@ -17,10 +19,10 @@ jobs:
     steps:
       - name: Resolve column IDs by name
         id: resolve
-        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const projectId = '${{ vars.PROJECT_ID }}';
             if (!projectId || projectId === '{{PROJECT_ID}}') {

--- a/.github/workflows/pdlc-health-check.yml
+++ b/.github/workflows/pdlc-health-check.yml
@@ -9,6 +9,8 @@ jobs:
   resolve-ids:
     name: Resolve Board Column IDs
     runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     outputs:
       project_id: ${{ steps.resolve.outputs.project_id }}
       status_field_id: ${{ steps.resolve.outputs.status_field_id }}
@@ -21,10 +23,10 @@ jobs:
     steps:
       - name: Resolve column IDs by name
         id: resolve
-        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const projectId = '${{ vars.PROJECT_ID }}';
             if (!projectId || projectId === '{{PROJECT_ID}}') {

--- a/.github/workflows/pdlc-health-check.yml
+++ b/.github/workflows/pdlc-health-check.yml
@@ -5,117 +5,115 @@ on:
   schedule:
     - cron: '0 8 * * 1' # Every Monday at 8am
 
-env:
-  PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
-  STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
-  STATUS_BRAINSTORMING: "8eb07c5b"
-  STATUS_DETAILING: "9f6ce70e"
-  STATUS_APPROVAL: "31bf4610"
-  STATUS_DEVELOPMENT: "2c9e78e6"
-  STATUS_TESTING: "96b59ade"
-  STATUS_CODE_REVIEW_PR: "86ca9720"
-  STATUS_PRODUCTION: "1581e5bd"
-
 jobs:
-  check-drift:
-    name: Detect Project Board Drift
+  resolve-ids:
+    name: Resolve Board Column IDs
     runs-on: ubuntu-latest
-    env:
-      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-    permissions:
-      issues: write
+    outputs:
+      project_id: ${{ steps.resolve.outputs.project_id }}
+      status_field_id: ${{ steps.resolve.outputs.status_field_id }}
+      status_brainstorming: ${{ steps.resolve.outputs.status_brainstorming }}
+      status_detailing: ${{ steps.resolve.outputs.status_detailing }}
+      status_approval: ${{ steps.resolve.outputs.status_approval }}
+      status_development: ${{ steps.resolve.outputs.status_development }}
+      status_code_review_pr: ${{ steps.resolve.outputs.status_code_review_pr }}
+      status_production: ${{ steps.resolve.outputs.status_production }}
     steps:
-      - name: Validate Board Configuration
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+      - name: Resolve column IDs by name
+        id: resolve
+        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ env.PROJECT_TOKEN }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const projectId = process.env.PROJECT_ID;
-            const statusFieldId = process.env.STATUS_FIELD_ID;
-            const envVars = {
-              'STATUS_BRAINSTORMING': process.env.STATUS_BRAINSTORMING,
-              'STATUS_DETAILING': process.env.STATUS_DETAILING,
-              'STATUS_APPROVAL': process.env.STATUS_APPROVAL,
-              'STATUS_DEVELOPMENT': process.env.STATUS_DEVELOPMENT,
-              'STATUS_TESTING': process.env.STATUS_TESTING,
-              'STATUS_CODE_REVIEW_PR': process.env.STATUS_CODE_REVIEW_PR,
-              'STATUS_PRODUCTION': process.env.STATUS_PRODUCTION
-            };
-
-            const query = `
-              query($projectId: ID!) {
-                node(id: $projectId) {
+            const projectId = '${{ vars.PROJECT_ID }}';
+            if (!projectId || projectId === '{{PROJECT_ID}}') {
+              core.warning('vars.PROJECT_ID not set — board features disabled');
+              return;
+            }
+            const { node } = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) {
                   ... on ProjectV2 {
-                    title
                     fields(first: 20) {
                       nodes {
                         ... on ProjectV2SingleSelectField {
                           id
                           name
-                          options {
-                            id
-                            name
-                          }
+                          options { id name }
                         }
                       }
                     }
                   }
                 }
               }
-            `;
+            `, { id: projectId });
+            const statusField = node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) { core.setFailed('Status field not found on board'); return; }
+            const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            core.setOutput('project_id', projectId);
+            core.setOutput('status_field_id', statusField.id);
+            core.setOutput('status_brainstorming',  opt('Brainstorming'));
+            core.setOutput('status_detailing',      opt('Detailing'));
+            core.setOutput('status_approval',       opt('Approval'));
+            core.setOutput('status_development',    opt('Development'));
+            core.setOutput('status_code_review_pr', opt('Code Review'));
+            core.setOutput('status_production',     opt('Production'));
+            console.log('✅ Board IDs resolved by name');
 
-            let result;
-            try {
-              result = await github.graphql(query, { projectId });
-            } catch (error) {
-              console.log("❌ Error fetching project. Verify your PROJECT_ID.");
-              console.log(error);
-              return;
-            }
+  check-drift:
+    name: Detect Project Board Drift
+    needs: [resolve-ids]
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+    permissions:
+      issues: write
+    steps:
+      - name: Validate Board Configuration
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const expectedColumns = [
+              'Brainstorming', 'Detailing', 'Approval',
+              'Development', 'Code Review', 'Production'
+            ];
 
-            const project = result.node;
-            if (!project) {
-              console.log("❌ Project not found.");
-              return;
-            }
+            const resolvedIds = {
+              'Brainstorming': '${{ needs.resolve-ids.outputs.status_brainstorming }}',
+              'Detailing':     '${{ needs.resolve-ids.outputs.status_detailing }}',
+              'Approval':      '${{ needs.resolve-ids.outputs.status_approval }}',
+              'Development':   '${{ needs.resolve-ids.outputs.status_development }}',
+              'Code Review':   '${{ needs.resolve-ids.outputs.status_code_review_pr }}',
+              'Production':    '${{ needs.resolve-ids.outputs.status_production }}',
+            };
 
-            const statusField = project.fields.nodes.find(f => f.id === statusFieldId);
-            if (!statusField) {
-              console.log("❌ Status field not found.");
-              return;
-            }
+            const missing = expectedColumns.filter(col => !resolvedIds[col]);
 
-            const validOptions = statusField.options;
-            const validOptionIds = validOptions.map(o => o.id);
-
-            let hasDrift = false;
-            let missingVars = [];
-
-            for (const [varName, id] of Object.entries(envVars)) {
-              if (id && !id.startsWith('{{') && !validOptionIds.includes(id)) {
-                hasDrift = true;
-                missingVars.push(varName);
-              }
-            }
-
-            if (hasDrift) {
-              console.log("🚨 Drift detected! The following mapped columns no longer exist: " + missingVars.join(", "));
-              
-              let table = "| Column Name | New ID |\n|---|---|\n";
-              validOptions.forEach(opt => {
-                table += `| ${opt.name} | \`${opt.id}\` |\n`;
-              });
-
-              const body = `🚨 **Agentic PDLC Drift Detected**\n\nThe following columns mapped in your \`.github/workflows/project-automation.yml\` no longer exist in your project board:\n\n**${missingVars.join(", ")}**\n\n### How to fix it:\nHere is the list of current columns in your board with their valid IDs. Please update the \`env\` block in your \`.github/workflows/project-automation.yml\` and \`.github/workflows/pdlc-health-check.yml\`.\n\n${table}`;
+            if (missing.length > 0) {
+              const body = [
+                '🚨 **Agentic PDLC Drift Detected**',
+                '',
+                'The following expected columns were not found on the board:',
+                '',
+                missing.map(c => `- **${c}**`).join('\n'),
+                '',
+                'The board may have been recreated or columns renamed.',
+                'Check `vars.PROJECT_ID` and verify column names match expected values.',
+              ].join('\n');
 
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: '🚨 Agentic PDLC Drift Detected in Project Board',
-                body: body,
+                body,
                 labels: ['bug']
               });
+
+              core.setFailed(`Missing columns: ${missing.join(', ')}`);
             } else {
-              console.log("✅ No drift detected. Board configuration is healthy.");
+              console.log('✅ No drift detected. All expected columns found on board.');
             }

--- a/.github/workflows/pdlc-health-check.yml
+++ b/.github/workflows/pdlc-health-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Resolve column IDs by name
         id: resolve
         if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Validate Board Configuration
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -13,6 +13,8 @@ jobs:
     name: Resolve Board Column IDs
     if: github.event_name != 'issues' || github.event.action != 'closed'
     runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     outputs:
       project_id: ${{ steps.resolve.outputs.project_id }}
       status_field_id: ${{ steps.resolve.outputs.status_field_id }}
@@ -25,10 +27,10 @@ jobs:
     steps:
       - name: Resolve column IDs by name
         id: resolve
-        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          github-token: ${{ env.PROJECT_TOKEN }}
           script: |
             const projectId = '${{ vars.PROJECT_ID }}';
             if (!projectId || projectId === '{{PROJECT_ID}}') {

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Resolve column IDs by name
         id: resolve
         if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Detect Label and Move Issue
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -144,7 +144,7 @@ jobs:
   #   steps:
   #     - name: Move issue to Idea
   #       if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-  #       uses: actions/github-script@v8
+  #       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
   #       with:
   #         github-token: ${{ env.PROJECT_TOKEN }}
   #         script: |
@@ -178,7 +178,7 @@ jobs:
     steps:
       - name: Move linked issue to Code Review / PR
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -240,7 +240,7 @@ jobs:
     steps:
       - name: Move linked issue to Code Review and swap PR labels
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -301,7 +301,7 @@ jobs:
     steps:
       - name: Move issue to Production
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
@@ -344,7 +344,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove transient labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,29 +8,80 @@ on:
   issues:
     types: [labeled, closed]
 
-env:
-  PROJECT_ID: "PVT_kwHODpFFL84BXg7h"
-  STATUS_FIELD_ID: "PVTSSF_lAHODpFFL84BXg7hzhStRHI"
-  STATUS_IDEA: "bb6e5a20"
-  STATUS_BRAINSTORMING: "8eb07c5b"
-  STATUS_DETAILING: "9f6ce70e"
-  STATUS_APPROVAL: "31bf4610"
-  STATUS_DEVELOPMENT: "2c9e78e6"
-  STATUS_TESTING: "96b59ade"
-  STATUS_CODE_REVIEW_PR: "86ca9720"
-  STATUS_PRODUCTION: "1581e5bd"
-
 jobs:
+  resolve-ids:
+    name: Resolve Board Column IDs
+    if: github.event_name != 'issues' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      project_id: ${{ steps.resolve.outputs.project_id }}
+      status_field_id: ${{ steps.resolve.outputs.status_field_id }}
+      status_brainstorming: ${{ steps.resolve.outputs.status_brainstorming }}
+      status_detailing: ${{ steps.resolve.outputs.status_detailing }}
+      status_approval: ${{ steps.resolve.outputs.status_approval }}
+      status_development: ${{ steps.resolve.outputs.status_development }}
+      status_code_review_pr: ${{ steps.resolve.outputs.status_code_review_pr }}
+      status_production: ${{ steps.resolve.outputs.status_production }}
+    steps:
+      - name: Resolve column IDs by name
+        id: resolve
+        if: ${{ secrets.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectId = '${{ vars.PROJECT_ID }}';
+            if (!projectId || projectId === '{{PROJECT_ID}}') {
+              core.warning('vars.PROJECT_ID not set — board features disabled');
+              return;
+            }
+            const { node } = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on ProjectV2 {
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { id: projectId });
+            const statusField = node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) { core.setFailed('Status field not found on board'); return; }
+            const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            core.setOutput('project_id', projectId);
+            core.setOutput('status_field_id', statusField.id);
+            core.setOutput('status_brainstorming',  opt('Brainstorming'));
+            core.setOutput('status_detailing',      opt('Detailing'));
+            core.setOutput('status_approval',       opt('Approval'));
+            core.setOutput('status_development',    opt('Development'));
+            core.setOutput('status_code_review_pr', opt('Code Review'));
+            core.setOutput('status_production',     opt('Production'));
+            console.log('✅ Board IDs resolved by name');
+
   # Issue Labeled → Move Upstream
   move-card-on-label:
     name: Upstream Label → Move Card
+    needs: [resolve-ids]
     if: github.event_name == 'issues' && github.event.action == 'labeled'
     runs-on: ubuntu-latest
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_BRAINSTORMING: ${{ needs.resolve-ids.outputs.status_brainstorming }}
+      STATUS_DETAILING: ${{ needs.resolve-ids.outputs.status_detailing }}
+      STATUS_APPROVAL: ${{ needs.resolve-ids.outputs.status_approval }}
+      STATUS_DEVELOPMENT: ${{ needs.resolve-ids.outputs.status_development }}
     steps:
       - name: Detect Label and Move Issue
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -60,34 +111,37 @@ jobs:
 
             const { issue: { number, node_id } } = context.payload;
 
-            const moveItem = async (nodeId, statusId) => {
-              const { addProjectV2ItemById: { item } } = await github.graphql(`
-                mutation($p: ID!, $c: ID!) {
-                  addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
-                }`, { p: process.env.PROJECT_ID, c: nodeId });
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($p: ID!, $c: ID!) {
+                addProjectV2ItemById(input: {projectId: $p, contentId: $c}) { item { id } }
+              }`, { p: process.env.PROJECT_ID, c: node_id });
 
-              await github.graphql(`
-                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
-                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
-                    projectV2Item { id }
-                  }
-                }`, {
-                  p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
-                  v: { singleSelectOptionId: statusId }
-                });
-            };
+            await github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                  projectV2Item { id }
+                }
+              }`, {
+                p: process.env.PROJECT_ID, i: item.id, f: process.env.STATUS_FIELD_ID,
+                v: { singleSelectOptionId: targetStatusId }
+              });
 
-            await moveItem(node_id, targetStatusId);
             console.log(`Issue #${number} moved to ${stageName}`);
 
   # OPTIONAL: Uncomment to enable architecture-violation → Idea
   # move-violation-to-board:
   #   name: architecture-violation → 💡 Idea
+  #   needs: [resolve-ids]
   #   if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'architecture-violation'
   #   runs-on: ubuntu-latest
+  #   env:
+  #     PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+  #     PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+  #     STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+  #     STATUS_IDEA: ${{ needs.resolve-ids.outputs.status_idea }}
   #   steps:
   #     - name: Move issue to Idea
-  #       if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+  #       if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
   #       uses: actions/github-script@v8
   #       with:
   #         github-token: ${{ env.PROJECT_TOKEN }}
@@ -111,13 +165,17 @@ jobs:
   # PR Opened → Move linked issue to Code Review / PR
   move-card-on-pr-open:
     name: Open PR → Code Review / PR
+    needs: [resolve-ids]
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_CODE_REVIEW_PR: ${{ needs.resolve-ids.outputs.status_code_review_pr }}
     steps:
       - name: Move linked issue to Code Review / PR
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -169,13 +227,17 @@ jobs:
   # Review Approved → Move linked issue to Code Review / PR + swap PR labels
   move-card-on-review-approved:
     name: Approved PR → Code Review / PR
+    needs: [resolve-ids]
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_CODE_REVIEW_PR: ${{ needs.resolve-ids.outputs.status_code_review_pr }}
     steps:
       - name: Move linked issue to Code Review and swap PR labels
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -226,13 +288,17 @@ jobs:
   # PR Merged → Production
   move-card-on-pr-merge:
     name: Merged PR → Production
+    needs: [resolve-ids]
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_PRODUCTION: ${{ needs.resolve-ids.outputs.status_production }}
     steps:
       - name: Move issue to Production
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `resolve-ids` job to `add-to-board.yml`, `agent-trigger.yml`, `project-automation.yml`, and `pdlc-health-check.yml`
- Each job queries the Projects V2 API at runtime to resolve column names → IDs using `vars.PROJECT_ID` (GitHub Actions Variable)
- All downstream jobs consume column IDs via `needs.resolve-ids.outputs.*` — zero hardcoded hex IDs remain in any YAML
- `cleanup-labels-on-close` and `trigger-agent-on-violation` intentionally excluded from `needs: [resolve-ids]` — no board moves needed
- `pdlc-health-check.yml` rewritten: checks that expected column names resolve successfully instead of validating stale hardcoded IDs
- `vars.PROJECT_ID` Actions Variable already set on this repo — no manual setup needed

## Follow-up

#179 — installer must set `vars.PROJECT_ID` via API for new repos instead of hardcoding in YAML

## Test plan

- [ ] Open a new issue — confirm it lands on the board in the Idea column
- [ ] Add `stage:brainstorming` label — confirm card moves to Brainstorming
- [ ] Open a PR — confirm linked issue card moves to Code Review
- [ ] Merge a PR — confirm linked issue moves to Production
- [ ] Run `pdlc-health-check.yml` manually — confirm "✅ No drift detected"
- [ ] Verify zero `PVT_`, `PVTSSF_`, or 8-char hex strings in any workflow YAML

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Board automation now resolves project and status options at runtime instead of relying on hardcoded IDs, making automation more resilient to board changes.
* **Bug Fixes**
  * Improved workflow safety: steps now skip cleanly when project configuration is missing and only run when required tokens/IDs are present.
  * Clearer drift detection and reporting when expected board columns are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->