### PR TITLE
feat(board): 6h reconciliation cron with shared derive-column.js

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -47,9 +47,11 @@ jobs:
             const statusField = node.fields.nodes.find(f => f.name === 'Status');
             if (!statusField) { core.setFailed('Status field not found on board'); return; }
             const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            const ideaId = opt('Idea');
+            if (!ideaId) { core.setFailed('Required Status column "Idea" not found on board'); return; }
             core.setOutput('project_id', projectId);
             core.setOutput('status_field_id', statusField.id);
-            core.setOutput('status_idea', opt('Idea'));
+            core.setOutput('status_idea', ideaId);
             console.log('✅ Board IDs resolved by name');
 
   add-to-board:

--- a/.github/workflows/board-reconciliation.yml
+++ b/.github/workflows/board-reconciliation.yml
@@ -1,0 +1,164 @@
+name: Board Reconciliation (Drift Heal)
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  resolve-ids:
+    name: Resolve Board Column IDs
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    outputs:
+      project_id: ${{ steps.resolve.outputs.project_id }}
+      status_field_id: ${{ steps.resolve.outputs.status_field_id }}
+      status_brainstorming: ${{ steps.resolve.outputs.status_brainstorming }}
+      status_detailing: ${{ steps.resolve.outputs.status_detailing }}
+      status_approval: ${{ steps.resolve.outputs.status_approval }}
+      status_development: ${{ steps.resolve.outputs.status_development }}
+      status_code_review_pr: ${{ steps.resolve.outputs.status_code_review_pr }}
+    steps:
+      - name: Resolve column IDs by name
+        id: resolve
+        if: ${{ env.PROJECT_TOKEN != '' && vars.PROJECT_ID != '' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const projectId = '${{ vars.PROJECT_ID }}';
+            if (!projectId || projectId === '{{PROJECT_ID}}') {
+              core.warning('vars.PROJECT_ID not set — board features disabled');
+              return;
+            }
+            const { node } = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on ProjectV2 {
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { id: projectId });
+            const statusField = node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) { core.setFailed('Status field not found on board'); return; }
+            const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            core.setOutput('project_id', projectId);
+            core.setOutput('status_field_id', statusField.id);
+            core.setOutput('status_brainstorming',  opt('Brainstorming'));
+            core.setOutput('status_detailing',      opt('Detailing'));
+            core.setOutput('status_approval',       opt('Approval'));
+            core.setOutput('status_development',    opt('Development'));
+            core.setOutput('status_code_review_pr', opt('Code Review'));
+            console.log('✅ Board IDs resolved by name');
+
+  reconcile-board:
+    name: Reconcile Board (idempotent drift heal)
+    needs: [resolve-ids]
+    if: needs.resolve-ids.outputs.project_id != ''
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: ${{ needs.resolve-ids.outputs.project_id }}
+      STATUS_FIELD_ID: ${{ needs.resolve-ids.outputs.status_field_id }}
+      STATUS_BRAINSTORMING: ${{ needs.resolve-ids.outputs.status_brainstorming }}
+      STATUS_DETAILING: ${{ needs.resolve-ids.outputs.status_detailing }}
+      STATUS_APPROVAL: ${{ needs.resolve-ids.outputs.status_approval }}
+      STATUS_DEVELOPMENT: ${{ needs.resolve-ids.outputs.status_development }}
+      STATUS_CODE_REVIEW_PR: ${{ needs.resolve-ids.outputs.status_code_review_pr }}
+    steps:
+      - uses: actions/checkout@v5.0.1
+      - name: Reconcile all open board items
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ env.PROJECT_TOKEN }}
+          script: |
+            const { classifyItem } = require('./scripts/derive-column.js');
+
+            const COLUMN_KEY_TO_ID = {
+              'code_review_pr': process.env.STATUS_CODE_REVIEW_PR,
+              'development':    process.env.STATUS_DEVELOPMENT,
+              'approval':       process.env.STATUS_APPROVAL,
+              'detailing':      process.env.STATUS_DETAILING,
+              'brainstorming':  process.env.STATUS_BRAINSTORMING,
+            };
+
+            // Paginate all board items
+            let allItems = [];
+            let cursor = null;
+            do {
+              const { node } = await github.graphql(`
+                query($id: ID!, $cursor: String) {
+                  node(id: $id) {
+                    ... on ProjectV2 {
+                      items(first: 50, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          id
+                          fieldValueByName(name: "Status") {
+                            ... on ProjectV2ItemFieldSingleSelectValue { optionId }
+                          }
+                          content {
+                            ... on Issue {
+                              number
+                              state
+                              labels(first: 20) { nodes { name } }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `, { id: process.env.PROJECT_ID, cursor });
+              const page = node.items;
+              allItems = allItems.concat(page.nodes);
+              cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+            } while (cursor);
+
+            let checked = 0, corrected = 0;
+
+            for (const item of allItems) {
+              // Skip PRs and closed issues
+              if (!item.content || item.content.state !== 'OPEN') continue;
+
+              const labelNames = item.content.labels.nodes.map(l => l.name);
+              const columnKey = classifyItem(labelNames);
+              if (!columnKey) continue; // no actionable label — skip (e.g. Idea column items)
+
+              const targetId = COLUMN_KEY_TO_ID[columnKey];
+              if (!targetId) continue; // column not resolved (shouldn't happen)
+
+              const currentId = item.fieldValueByName?.optionId ?? null;
+              checked++;
+
+              if (currentId === targetId) continue; // already correct — no mutation
+
+              await github.graphql(`
+                mutation($p: ID!, $i: ID!, $f: ID!, $v: ProjectV2FieldValue!) {
+                  updateProjectV2ItemFieldValue(input: {projectId: $p, itemId: $i, fieldId: $f, value: $v}) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                p: process.env.PROJECT_ID,
+                i: item.id,
+                f: process.env.STATUS_FIELD_ID,
+                v: { singleSelectOptionId: targetId },
+              });
+
+              corrected++;
+              console.log(`Corrected #${item.content.number}: ${currentId ?? 'none'} → ${columnKey}`);
+            }
+
+            console.log(`✅ Reconciliation complete: ${checked} items checked, ${corrected} corrected`);

--- a/.github/workflows/board-reconciliation.yml
+++ b/.github/workflows/board-reconciliation.yml
@@ -52,13 +52,25 @@ jobs:
             const statusField = node.fields.nodes.find(f => f.name === 'Status');
             if (!statusField) { core.setFailed('Status field not found on board'); return; }
             const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            const ids = {
+              brainstorming:  opt('Brainstorming'),
+              detailing:      opt('Detailing'),
+              approval:       opt('Approval'),
+              development:    opt('Development'),
+              code_review_pr: opt('Code Review'),
+            };
+            const missing = Object.entries(ids).filter(([, v]) => !v).map(([k]) => k);
+            if (missing.length > 0) {
+              core.setFailed(`Required Status columns not found on board: ${missing.join(', ')}`);
+              return;
+            }
             core.setOutput('project_id', projectId);
             core.setOutput('status_field_id', statusField.id);
-            core.setOutput('status_brainstorming',  opt('Brainstorming'));
-            core.setOutput('status_detailing',      opt('Detailing'));
-            core.setOutput('status_approval',       opt('Approval'));
-            core.setOutput('status_development',    opt('Development'));
-            core.setOutput('status_code_review_pr', opt('Code Review'));
+            core.setOutput('status_brainstorming',  ids.brainstorming);
+            core.setOutput('status_detailing',      ids.detailing);
+            core.setOutput('status_approval',       ids.approval);
+            core.setOutput('status_development',    ids.development);
+            core.setOutput('status_code_review_pr', ids.code_review_pr);
             console.log('✅ Board IDs resolved by name');
 
   reconcile-board:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -84,30 +84,35 @@ jobs:
       STATUS_CODE_REVIEW_PR: ${{ needs.resolve-ids.outputs.status_code_review_pr }}
       STATUS_PRODUCTION: ${{ needs.resolve-ids.outputs.status_production }}
     steps:
+      - uses: actions/checkout@v5.0.1
       - name: Dispatch board move
         if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
           script: |
+            const { classifyItem } = require('./scripts/derive-column.js');
             const { owner, repo } = context.repo;
             const eventName = context.eventName;
             const action = context.payload.action;
+
+            const COLUMN_KEY_TO_ENV = {
+              'code_review_pr': 'STATUS_CODE_REVIEW_PR',
+              'development':    'STATUS_DEVELOPMENT',
+              'approval':       'STATUS_APPROVAL',
+              'detailing':      'STATUS_DETAILING',
+              'brainstorming':  'STATUS_BRAINSTORMING',
+            };
 
             // f(event) → { targetStatusId, linkedNodeIds, stageLabelsToClear, prLabelSwap }
             async function deriveMove() {
               const col = (key) => process.env[key];
 
-              // Issue labeled → stage column
+              // Issue labeled → stage column (uses shared classify logic)
               if (eventName === 'issues' && action === 'labeled') {
-                const labelMap = {
-                  'stage:brainstorming': col('STATUS_BRAINSTORMING'),
-                  'stage:detailing':     col('STATUS_DETAILING'),
-                  'stage:approval':      col('STATUS_APPROVAL'),
-                  'stage:development':   col('STATUS_DEVELOPMENT'),
-                };
                 const label = context.payload.label.name;
-                const targetStatusId = labelMap[label];
+                const columnKey = classifyItem([label]);
+                const targetStatusId = columnKey ? col(COLUMN_KEY_TO_ENV[columnKey]) : null;
                 if (!targetStatusId) return null;
                 return {
                   targetStatusId,

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -57,14 +57,27 @@ jobs:
             const statusField = node.fields.nodes.find(f => f.name === 'Status');
             if (!statusField) { core.setFailed('Status field not found on board'); return; }
             const opt = (name) => statusField.options.find(o => o.name.includes(name))?.id ?? '';
+            const ids = {
+              brainstorming:  opt('Brainstorming'),
+              detailing:      opt('Detailing'),
+              approval:       opt('Approval'),
+              development:    opt('Development'),
+              code_review_pr: opt('Code Review'),
+              production:     opt('Production'),
+            };
+            const missing = Object.entries(ids).filter(([, v]) => !v).map(([k]) => k);
+            if (missing.length > 0) {
+              core.setFailed(`Required Status columns not found on board: ${missing.join(', ')}`);
+              return;
+            }
             core.setOutput('project_id', projectId);
             core.setOutput('status_field_id', statusField.id);
-            core.setOutput('status_brainstorming',  opt('Brainstorming'));
-            core.setOutput('status_detailing',      opt('Detailing'));
-            core.setOutput('status_approval',       opt('Approval'));
-            core.setOutput('status_development',    opt('Development'));
-            core.setOutput('status_code_review_pr', opt('Code Review'));
-            core.setOutput('status_production',     opt('Production'));
+            core.setOutput('status_brainstorming',  ids.brainstorming);
+            core.setOutput('status_detailing',      ids.detailing);
+            core.setOutput('status_approval',       ids.approval);
+            core.setOutput('status_development',    ids.development);
+            core.setOutput('status_code_review_pr', ids.code_review_pr);
+            core.setOutput('status_production',     ids.production);
             console.log('✅ Board IDs resolved by name');
 
   # Single dispatcher — f(event) → target column → move card
@@ -110,8 +123,8 @@ jobs:
 
               // Issue labeled → stage column (uses shared classify logic)
               if (eventName === 'issues' && action === 'labeled') {
-                const label = context.payload.label.name;
-                const columnKey = classifyItem([label]);
+                const labelNames = (context.payload.issue.labels ?? []).map(l => l.name);
+                const columnKey = classifyItem(labelNames);
                 const targetStatusId = columnKey ? col(COLUMN_KEY_TO_ENV[columnKey]) : null;
                 if (!targetStatusId) return null;
                 return {

--- a/scripts/derive-column.js
+++ b/scripts/derive-column.js
@@ -1,0 +1,20 @@
+// Single source of truth for label → board column classification.
+// Used by the event dispatcher (project-automation.yml) and the reconciliation cron (board-reconciliation.yml).
+// pr:* beats stage:* — a live PR is higher-confidence signal than a stage label that may not have been cleaned up.
+const LABEL_PRIORITY = [
+  { label: 'pr:in-review',        column: 'code_review_pr' },
+  { label: 'pr:approved',         column: 'code_review_pr' },
+  { label: 'stage:development',   column: 'development' },
+  { label: 'stage:approval',      column: 'approval' },
+  { label: 'stage:detailing',     column: 'detailing' },
+  { label: 'stage:brainstorming', column: 'brainstorming' },
+];
+
+function classifyItem(labelNames) {
+  for (const { label, column } of LABEL_PRIORITY) {
+    if (labelNames.includes(label)) return column;
+  }
+  return null;
+}
+
+module.exports = { classifyItem, LABEL_PRIORITY };


### PR DESCRIPTION
## Summary

- Adds `scripts/derive-column.js` — single source of truth for label→column classification (`classifyItem(labels) → columnKey`). `pr:*` beats `stage:*` to handle anti-loop scenarios.
- Adds `board-reconciliation.yml` — runs every 6h + `workflow_dispatch`. Paginates all open board items, computes correct column from labels, corrects drift. Logs `N checked, M corrected`.
- Updates `project-automation.yml` — adds `actions/checkout` to `move-card` job, replaces inline `labelMap` with `classifyItem()` from shared script.

Dispatcher and cron now share the same classification path. A label rename requires one change, not two.

## Test plan

- [ ] Trigger `workflow_dispatch` on `board-reconciliation.yml` after merge — verify run completes with `N checked, 0 corrected` (clean board)
- [ ] Drag a card manually to wrong column → wait for cron (or re-trigger `workflow_dispatch`) → verify card moves back
- [ ] Apply `stage:development` label to an issue → verify dispatcher still moves card to Development column (shared script path)
- [ ] Verify `board-reconciliation.yml` logs `M corrected` > 0 only when drift exists

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated board reconciliation to periodically scan project items and correct mismatched issue status fields.

* **Chores**
  * Centralized label-to-column classification into a single shared rule set for consistent mapping across workflows.
  * Made automation more robust: improved column-resolution checks, fail-fast when required columns are missing, and ensured workflows run with the repository checked out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->