### PR TITLE
chore(board): drop Testing column and stage:testing label

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -142,7 +142,7 @@ jobs:
                 const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
                 const linkedIssues = [...(pr.body ?? '').matchAll(/(?:Closes?|Fixes?|Resolves?)\s+#(\d+)/gi)]
                   .map(m => parseInt(m[1]));
-                const stageLabels = ['stage:development', 'stage:brainstorming', 'stage:detailing', 'stage:testing', 'jules'];
+                const stageLabels = ['stage:development', 'stage:brainstorming', 'stage:detailing', 'jules'];
 
                 if (linkedIssues.length > 0) {
                   const nodes = await Promise.all(linkedIssues.map(async n => {
@@ -183,7 +183,7 @@ jobs:
                     targetStatusId: col('STATUS_CODE_REVIEW_PR'),
                     nodeIds: nodes.map(n => n.nodeId),
                     issueNumbers: nodes.map(n => n.issueNumber),
-                    stageLabelsToClear: ['stage:testing'],
+                    stageLabelsToClear: [],
                     prLabelSwap: { remove: 'pr:in-review', add: 'pr:approved', prNumber },
                   };
                 } else {
@@ -331,7 +331,7 @@ jobs:
             const issue_number = context.payload.issue.number;
             const toRemove = [
               'stage:brainstorming', 'stage:detailing',
-              'stage:approval', 'stage:development', 'stage:testing',
+              'stage:approval', 'stage:development',
               'pr:in-review', 'jules'
             ];
             for (const label of toRemove) {


### PR DESCRIPTION
## Summary

- Testing column deleted from board via `updateProjectV2Field` GraphQL mutation (done pre-PR — column is already gone)
- `stage:testing` repo label deleted
- 3 references removed from `project-automation.yml`: `stageLabels` array, `stageLabelsToClear` in PR review approved path, `cleanup-labels-on-close` toRemove list

No cards have been routed to Testing since QA Agent removal in #153.

## Test plan

- [ ] Verify Testing column does not appear on board
- [ ] Verify `stage:testing` label does not exist in repo labels
- [ ] Open a PR → verify `stageLabels` no longer attempts to remove `stage:testing` from linked issue
- [ ] Merge a PR → verify `cleanup-labels-on-close` works without errors

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions board automation workflow to refine stage label management during pull request review and issue closure processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->