### PR TITLE
feat(cli): set PROJECT_ID as Actions Variable during install (#179)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -80,6 +80,16 @@ const i18n = {
     '✅ Issue templates copiados para .github/ISSUE_TEMPLATE/',
     '✅ Issue templates copiados a .github/ISSUE_TEMPLATE/'
   ),
+  vars_project_id_ok: t(
+    '✅ vars.PROJECT_ID set as Actions Variable.',
+    '✅ vars.PROJECT_ID configurado como Variável do Actions.',
+    '✅ vars.PROJECT_ID configurado como Variable de Actions.'
+  ),
+  vars_project_id_warn: t(
+    '⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ',
+    '⚠️  Não foi possível configurar vars.PROJECT_ID — o token pode não ter permissão variables:write.\n   Configure manualmente: repo Settings → Secrets and variables → Variables → PROJECT_ID = ',
+    '⚠️  No se pudo configurar vars.PROJECT_ID — el token puede no tener permiso variables:write.\n   Configura manualmente: repo Settings → Secrets and variables → Variables → PROJECT_ID = '
+  ),
 };
 
 const cyan = '\x1b[36m';
@@ -579,9 +589,9 @@ async function runFullSetup() {
   if (projectId) {
     try {
       setActionsVariable(repo, 'PROJECT_ID', projectId);
-      console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+      console.log(`${green}${i18n.vars_project_id_ok}${reset}`);
     } catch (_) {
-      console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+      console.log(`${yellow}${i18n.vars_project_id_warn}${projectId}${reset}`);
     }
   }
 
@@ -1041,9 +1051,9 @@ async function runUpgradeToAgentic() {
   if (projectId) {
     try {
       setActionsVariable(repo, 'PROJECT_ID', projectId);
-      console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+      console.log(`${green}${i18n.vars_project_id_ok}${reset}`);
     } catch (_) {
-      console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+      console.log(`${yellow}${i18n.vars_project_id_warn}${projectId}${reset}`);
     }
   }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1037,6 +1037,16 @@ async function runUpgradeToAgentic() {
     }
   }
 
+  // Set PROJECT_ID as GitHub Actions Variable
+  if (projectId) {
+    try {
+      setActionsVariable(repo, 'PROJECT_ID', projectId);
+      console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+    } catch (_) {
+      console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+    }
+  }
+
   console.log(`\n${yellow}${i18n.scaffolding}${reset}`);
   scaffoldFullTemplates(sourceDir, targetDir, projectId, statusFieldId, optionMap, repoOwner, repoName);
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -575,6 +575,16 @@ async function runFullSetup() {
     console.log(`\n${yellow}ℹ️  Org repo detected — PROJECT_PAT will require manual setup for security.${reset}`);
   }
 
+  // Set PROJECT_ID as GitHub Actions Variable
+  if (projectId) {
+    try {
+      setActionsVariable(repo, 'PROJECT_ID', projectId);
+      console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+    } catch (_) {
+      console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+    }
+  }
+
   await setBranchProtection(repo, ['PDLC Stage Gate', 'QA Gate']);
 
   console.log(`\n${yellow}${i18n.scaffolding}${reset}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -342,7 +342,6 @@ function scaffoldFullTemplates(sourceDir, targetDir, projectId, statusFieldId, o
   const paPath = path.join(destTemplates, '.github', 'workflows', 'project-automation.yml');
   if (fs.existsSync(paPath) && Object.keys(optionMap).length > 0) {
     let wfContent = fs.readFileSync(paPath, 'utf8');
-    if (projectId)     wfContent = wfContent.replace(/\{\{PROJECT_ID\}\}/g,      () => projectId);
     if (statusFieldId) wfContent = wfContent.replace(/\{\{STATUS_FIELD_ID\}\}/g, () => statusFieldId);
     wfContent = wfContent.replace(/\{\{ID_IDEA\}\}/g,                () => optionMap['💡 Idea - No move to Exploration directly'] || 'MISSING_ID');
     wfContent = wfContent.replace(/\{\{ID_EXPLORATION\}\}/g,         () => optionMap['🔍 Exploration']         || 'MISSING_ID');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -282,6 +282,29 @@ function scaffoldLiteTemplates(sourceDir, targetDir) {
   }
 }
 
+function setActionsVariable(repo, name, value, execFn = execFileSync) {
+  try {
+    execFn('gh', [
+      'api', `repos/${repo}/actions/variables/${name}`,
+      '--method', 'PATCH',
+      '-f', `name=${name}`,
+      '-f', `value=${value}`
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const msg = (err.stderr?.toString() || '') + (err.message || '');
+    if (msg.includes('404') || msg.includes('Not Found')) {
+      execFn('gh', [
+        'api', `repos/${repo}/actions/variables`,
+        '--method', 'POST',
+        '-f', `name=${name}`,
+        '-f', `value=${value}`
+      ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    } else {
+      throw err;
+    }
+  }
+}
+
 function scaffoldFullTemplates(sourceDir, targetDir, projectId, statusFieldId, optionMap, repoOwner, repoName) {
   const destTemplates = path.join(targetDir, '.agentic-pdlc', 'templates');
   fs.mkdirSync(destTemplates, { recursive: true });
@@ -789,7 +812,7 @@ function resolveMode(args) {
 }
 
 // Export for testing
-if (typeof module !== 'undefined') module.exports = { resolveMode };
+if (typeof module !== 'undefined') module.exports = { resolveMode, setActionsVariable };
 
 // ─── runLiteSetup ─────────────────────────────────────────────────────────────
 

--- a/docs/superpowers/plans/2026-06-05-project-id-actions-variable.md
+++ b/docs/superpowers/plans/2026-06-05-project-id-actions-variable.md
@@ -1,0 +1,336 @@
+# PROJECT_ID as Actions Variable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace hardcoded `PROJECT_ID: "PVT_xxx"` in installed YAML files with `${{ vars.PROJECT_ID }}`, and have the installer set the value via the GitHub Actions Variables REST API.
+
+**Architecture:** Three workflow templates swap their `PROJECT_ID` env value and guard condition. `bin/cli.js` gains a `setActionsVariable(repo, name, value, execFn)` helper (dependency-injected `execFn` for testability) called after board creation in both the `runFullSetup` and `runUpgradeToAgentic` flows.
+
+**Tech Stack:** Node.js 22, `node:test` + `node:assert/strict`, `gh` CLI (`execFileSync`), GitHub Actions Variables REST API (`PATCH`/`POST /repos/{owner}/{repo}/actions/variables`).
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `templates/.github/workflows/project-automation.yml` | Remove `{{PROJECT_ID}}` placeholder, source from `vars` |
+| Modify | `templates/.github/workflows/add-to-board.yml` | Same |
+| Modify | `templates/.github/workflows/agent-trigger.yml` | Same |
+| Modify | `bin/cli.js` | Add helper, wire call sites, export helper |
+| Modify | `tests/cli.test.js` | Tests for `setActionsVariable` logic |
+
+---
+
+### Task 1: Update workflow templates
+
+**Files:**
+- Modify: `templates/.github/workflows/project-automation.yml`
+- Modify: `templates/.github/workflows/add-to-board.yml`
+- Modify: `templates/.github/workflows/agent-trigger.yml`
+
+No tests for template content — correctness is verified by the installer integration.
+
+- [ ] **Step 1: Replace `PROJECT_ID` env value in all three templates**
+
+In each of the three files, find every line matching:
+```yaml
+PROJECT_ID: "{{PROJECT_ID}}"
+```
+Replace with:
+```yaml
+PROJECT_ID: ${{ vars.PROJECT_ID }}
+```
+
+`project-automation.yml` line 12, `add-to-board.yml` line 8, `agent-trigger.yml` line 21.
+
+- [ ] **Step 2: Replace guard conditions in all three templates**
+
+In each of the three files, find every line matching:
+```yaml
+env.PROJECT_ID != '{{PROJECT_ID}}'
+```
+Replace with:
+```yaml
+env.PROJECT_ID != ''
+```
+
+Do a full-file search in each — there are multiple occurrences per file (every job that conditionally runs).
+
+- [ ] **Step 3: Verify no `{{PROJECT_ID}}` remains in workflow files**
+
+Run:
+```bash
+grep -rn "{{PROJECT_ID}}" templates/.github/workflows/
+```
+
+Expected: no output. If any lines appear, fix them before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/.github/workflows/project-automation.yml \
+        templates/.github/workflows/add-to-board.yml \
+        templates/.github/workflows/agent-trigger.yml
+git commit -m "feat(templates): source PROJECT_ID from vars instead of hardcoded placeholder"
+```
+
+---
+
+### Task 2: Remove `{{PROJECT_ID}}` YAML substitution from `scaffoldFullTemplates`
+
+**Files:**
+- Modify: `bin/cli.js:345`
+
+- [ ] **Step 1: Delete the single PROJECT_ID substitution line**
+
+In `bin/cli.js`, find and remove exactly this line (currently line 345):
+```javascript
+    if (projectId)     wfContent = wfContent.replace(/\{\{PROJECT_ID\}\}/g,      () => projectId);
+```
+
+The block around it (lines 342–356) substitutes `STATUS_FIELD_ID` and all `ID_*` column options into `project-automation.yml`. Keep all those lines. Only the `PROJECT_ID` line is removed.
+
+- [ ] **Step 2: Verify other substitutions are intact**
+
+Run:
+```bash
+grep -n "wfContent.replace" bin/cli.js
+```
+
+Expected output must include lines for `STATUS_FIELD_ID`, `ID_IDEA`, `ID_BRAINSTORMING`, `ID_DETAILING`, `ID_APPROVAL`, `ID_DEVELOPMENT`, `ID_TESTING`, `ID_CODE_REVIEW_PR`, `ID_PRODUCTION`. Must NOT include `PROJECT_ID`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bin/cli.js
+git commit -m "fix(cli): remove PROJECT_ID hardcoding from scaffoldFullTemplates"
+```
+
+---
+
+### Task 3: Add `setActionsVariable` helper (TDD)
+
+**Files:**
+- Modify: `bin/cli.js` (add function before `scaffoldFullTemplates`, ~line 283)
+- Modify: `tests/cli.test.js` (add describe block)
+- Modify: `bin/cli.js:793` (add to `module.exports`)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/cli.test.js`:
+
+```javascript
+const { describe, it, mock } = require('node:test');
+
+// ... existing imports and tests above ...
+
+describe('setActionsVariable', () => {
+  it('calls PATCH first', () => {
+    const calls = [];
+    const execFn = (cmd, args) => { calls.push(args); };
+    const { setActionsVariable } = require('../bin/cli.js');
+    setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].includes('--method'));
+    assert.ok(calls[0].includes('PATCH'));
+    assert.ok(calls[0].some(a => a.includes('PROJECT_ID')));
+  });
+
+  it('falls back to POST on 404', () => {
+    const calls = [];
+    let callCount = 0;
+    const execFn = (cmd, args) => {
+      calls.push([...args]);
+      callCount++;
+      if (callCount === 1) {
+        const err = new Error('Not Found');
+        err.stderr = Buffer.from('Not Found');
+        throw err;
+      }
+    };
+    const { setActionsVariable } = require('../bin/cli.js');
+    setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
+    assert.equal(calls.length, 2);
+    assert.ok(calls[0].includes('PATCH'));
+    assert.ok(calls[1].includes('POST'));
+  });
+
+  it('throws on 403', () => {
+    const execFn = () => {
+      const err = new Error('Forbidden');
+      err.stderr = Buffer.from('Forbidden');
+      throw err;
+    };
+    const { setActionsVariable } = require('../bin/cli.js');
+    assert.throws(
+      () => setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn),
+      /Forbidden/
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test
+```
+
+Expected: 3 new test failures — `setActionsVariable` is not exported yet.
+
+- [ ] **Step 3: Add `setActionsVariable` to `bin/cli.js`**
+
+Insert this function before `scaffoldFullTemplates` (~line 283):
+
+```javascript
+function setActionsVariable(repo, name, value, execFn = execFileSync) {
+  try {
+    execFn('gh', [
+      'api', `repos/${repo}/actions/variables/${name}`,
+      '--method', 'PATCH',
+      '-f', `name=${name}`,
+      '-f', `value=${value}`
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const msg = (err.stderr?.toString() || '') + (err.message || '');
+    if (msg.includes('404') || msg.includes('Not Found')) {
+      execFn('gh', [
+        'api', `repos/${repo}/actions/variables`,
+        '--method', 'POST',
+        '-f', `name=${name}`,
+        '-f', `value=${value}`
+      ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    } else {
+      throw err;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Export the function**
+
+In `bin/cli.js` at line 793, update:
+```javascript
+if (typeof module !== 'undefined') module.exports = { resolveMode };
+```
+to:
+```javascript
+if (typeof module !== 'undefined') module.exports = { resolveMode, setActionsVariable };
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass including the 3 new `setActionsVariable` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bin/cli.js tests/cli.test.js
+git commit -m "feat(cli): add setActionsVariable helper with PATCH→POST fallback"
+```
+
+---
+
+### Task 4: Wire `setActionsVariable` into the create flow (`runFullSetup`)
+
+**Files:**
+- Modify: `bin/cli.js` (~line 554)
+
+- [ ] **Step 1: Add the call site after the PROJECT_PAT block**
+
+In `bin/cli.js`, locate the end of the `PROJECT_PAT` block in `runFullSetup` (the `} else if (projectId && isOrg)` line at ~554). Add after it:
+
+```javascript
+  // Set PROJECT_ID as GitHub Actions Variable
+  if (projectId) {
+    try {
+      setActionsVariable(repo, 'PROJECT_ID', projectId);
+      console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+    } catch (_) {
+      console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+    }
+  }
+```
+
+Insert this block between line 554 (`} else if (projectId && isOrg) { ... }`) and line 556 (`await setBranchProtection(...)`).
+
+- [ ] **Step 2: Verify placement**
+
+```bash
+grep -n "vars.PROJECT_ID\|setBranchProtection\|isOrg\)" bin/cli.js | head -20
+```
+
+The `vars.PROJECT_ID` console log should appear between the `isOrg` block and `setBranchProtection`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bin/cli.js
+git commit -m "feat(cli): set vars.PROJECT_ID as Actions Variable in create flow"
+```
+
+---
+
+### Task 5: Wire `setActionsVariable` into the upgrade flow (`runUpgradeToAgentic`)
+
+**Files:**
+- Modify: `bin/cli.js` (~line 1006)
+
+- [ ] **Step 1: Add the call site after the PROJECT_PAT block in the upgrade flow**
+
+In `bin/cli.js`, locate the end of the `PROJECT_PAT` block in `runUpgradeToAgentic` (the closing `}` of `if (projectId && !isOrg)` at ~line 1006). Add after it:
+
+```javascript
+  // Set PROJECT_ID as GitHub Actions Variable
+  if (projectId) {
+    try {
+      setActionsVariable(repo, 'PROJECT_ID', projectId);
+      console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+    } catch (_) {
+      console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+    }
+  }
+```
+
+Insert between line ~1006 (`}` closing the `PROJECT_PAT` block) and line ~1008 (`console.log scaffolding`).
+
+- [ ] **Step 2: Verify no `{{PROJECT_ID}}` placeholder survives install**
+
+```bash
+grep -rn "{{PROJECT_ID}}" templates/
+```
+
+Expected: only `templates/full/docs/pdlc.md` (the documentation file). No workflow YAML files.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bin/cli.js
+git commit -m "feat(cli): set vars.PROJECT_ID as Actions Variable in upgrade flow"
+```
+
+---
+
+## Self-Review Checklist
+
+- Acceptance Criteria 1 (new install sets `vars.PROJECT_ID`): Task 4 ✓
+- Acceptance Criteria 2 (`resolve-ids` works without YAML modification): Task 1 ✓
+- Acceptance Criteria 3 (`--update` sets variable): Task 5 ✓
+- Acceptance Criteria 4 (403 warning, non-fatal): Tasks 3, 4, 5 ✓
+- Edge case — PATCH first, POST on 404: Task 3 ✓
+- Edge case — `vars.PROJECT_ID` unset resolves to `''`, guard works: Task 1 ✓
+- No `{{PROJECT_ID}}` in any YAML after install: Tasks 1 + 2 ✓
+- All other ID substitutions preserved: Task 2 Step 2 ✓

--- a/docs/superpowers/specs/2026-06-05-project-id-actions-variable-design.md
+++ b/docs/superpowers/specs/2026-06-05-project-id-actions-variable-design.md
@@ -1,0 +1,114 @@
+# Design: Set PROJECT_ID as Actions Variable During Install
+
+**Issue:** #179
+**Date:** 2026-06-05
+**Status:** Approved
+
+## Problem
+
+The `create-agentic-pdlc` installer embeds the GitHub Project ID (`PVT_xxx`) directly into workflow YAML files by replacing `{{PROJECT_ID}}` placeholders during `scaffoldFullTemplates`. This means new repo installs get workflows with a hardcoded value in source-controlled files — brittle, hard to rotate, and inconsistent with how GitHub recommends storing non-secret configuration.
+
+The fix: set `vars.PROJECT_ID` as a GitHub Actions Variable via the REST API during install, and have workflow templates source it from `vars` at runtime.
+
+## Approach: env block sourced from `vars`
+
+Keep the `PROJECT_ID:` entry in the workflow-level `env` block — just change its value from a hardcoded placeholder to `${{ vars.PROJECT_ID }}`. All `process.env.PROJECT_ID` references inside `actions/github-script` bodies remain unchanged. Minimal diff, maximum behavioral parity.
+
+Rejected alternatives:
+- **Inline `vars` everywhere**: larger diff, all script bodies change, no benefit.
+- **Set vars + keep YAML hardcode**: adds complexity, defeats the goal.
+
+## Changes
+
+### 1. Templates — 3 workflow files
+
+Files: `templates/.github/workflows/project-automation.yml`, `add-to-board.yml`, `agent-trigger.yml`
+
+Every occurrence of:
+
+| Before | After |
+|---|---|
+| `PROJECT_ID: "{{PROJECT_ID}}"` | `PROJECT_ID: ${{ vars.PROJECT_ID }}` |
+| `env.PROJECT_ID != '{{PROJECT_ID}}'` | `env.PROJECT_ID != ''` |
+
+Guard correctness: when `vars.PROJECT_ID` is unset, `${{ vars.PROJECT_ID }}` resolves to `''` at workflow startup → `env.PROJECT_ID != ''` suppresses execution cleanly. Verified: `vars.*` in workflow-level `env` block resolves before jobs run.
+
+`pdlc.md` keeps `{{PROJECT_ID}}` substitution — it is a documentation file, not a YAML workflow.
+
+### 2. `bin/cli.js` — new helper `setActionsVariable`
+
+```javascript
+function setActionsVariable(repo, name, value) {
+  try {
+    execFileSync('gh', ['api', `repos/${repo}/actions/variables/${name}`,
+      '--method', 'PATCH', '-f', `name=${name}`, '-f', `value=${value}`],
+      { stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const msg = err.stderr?.toString() || '';
+    if (msg.includes('404') || msg.includes('Not Found')) {
+      execFileSync('gh', ['api', `repos/${repo}/actions/variables`,
+        '--method', 'POST', '-f', `name=${name}`, '-f', `value=${value}`],
+        { stdio: ['ignore', 'pipe', 'pipe'] });
+    } else {
+      throw err; // 403 bubbles up → caller emits user-visible warning
+    }
+  }
+}
+```
+
+Uses `gh api` via `execFileSync` — consistent with all other API calls in `cli.js`. PATCH on existing variable, POST on 404, throws on 403 so the caller can warn the user.
+
+**Token scope requirement:** fine-grained PAT needs `variables:write`; classic PAT needs `repo` scope. `GITHUB_TOKEN` (workflow-issued) will return 403 — cannot set repo variables. The installer already calls `gh auth token` for `PROJECT_PAT`; the same authenticated session is used here.
+
+### 3. `bin/cli.js` — `scaffoldFullTemplates` (line 345)
+
+Remove the single line that substitutes `{{PROJECT_ID}}` in `project-automation.yml`:
+
+```javascript
+// REMOVE this line:
+if (projectId) wfContent = wfContent.replace(/\{\{PROJECT_ID\}\}/g, () => projectId);
+```
+
+All other substitutions on lines 346–355 (`STATUS_FIELD_ID`, `ID_BRAINSTORMING`, `ID_DETAILING`, etc.) are preserved unchanged.
+
+### 4. Create flow — call site
+
+Inside the existing `if (projectId)` block (after `PROJECT_PAT` secret is set, ~line 541):
+
+```javascript
+try {
+  setActionsVariable(repo, 'PROJECT_ID', projectId);
+  console.log(`${green}✅ vars.PROJECT_ID set as Actions Variable.${reset}`);
+} catch (_) {
+  console.log(`${yellow}⚠️  Could not set vars.PROJECT_ID — token may lack variables:write scope.\n   Set it manually: repo Settings → Secrets and variables → Variables → PROJECT_ID = ${projectId}${reset}`);
+}
+```
+
+Non-fatal. Install continues regardless.
+
+### 5. `--update` flow — same call site
+
+The `--update` command is a **lite → full upgrade** — it exits early if the profile is already `full` (line 865). For lite → full, a new board is created via `createProjectV2` (line 920), producing a fresh `projectId`. Call `setActionsVariable` in the same `if (projectId)` block after board creation. Identical error handling to the create flow.
+
+No "find existing project" query is needed. `projectId` is always available from the mutation result in both flows.
+
+## Acceptance Criteria
+
+- `npx create-agentic-pdlc` → `vars.PROJECT_ID` set as GitHub Actions Variable on the target repo
+- No `PVT_xxx` value appears in any installed YAML file
+- `resolve-ids` job resolves column IDs without any YAML modification
+- `--update` (lite → full) → `vars.PROJECT_ID` set with the newly created board ID
+- If token lacks scope → installer prints actionable warning with manual steps; install does not abort
+
+## Out of Scope
+
+- Migrating existing full installs (board already set up, YAML already hardcoded)
+- Changing how `PROJECT_ID` is resolved during install (GraphQL flow unchanged)
+- `--update` on an already-full install (exits early before any board logic runs)
+
+## Files to Modify
+
+- `templates/.github/workflows/project-automation.yml`
+- `templates/.github/workflows/add-to-board.yml`
+- `templates/.github/workflows/agent-trigger.yml`
+- `bin/cli.js` — `setActionsVariable` helper, `scaffoldFullTemplates` line 345, create flow call site, update flow call site

--- a/templates/.github/workflows/add-to-board.yml
+++ b/templates/.github/workflows/add-to-board.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 env:
-  PROJECT_ID: "{{PROJECT_ID}}"
+  PROJECT_ID: ${{ vars.PROJECT_ID }}
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
   STATUS_IDEA: "{{ID_IDEA}}"
 
@@ -17,7 +17,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Add issue to project board
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}

--- a/templates/.github/workflows/agent-trigger.yml
+++ b/templates/.github/workflows/agent-trigger.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     env:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-      PROJECT_ID: "{{PROJECT_ID}}"
+      PROJECT_ID: ${{ vars.PROJECT_ID }}
       STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
       STATUS_DEVELOPMENT: "{{ID_DEVELOPMENT}}"
     steps:
@@ -62,7 +62,7 @@ jobs:
             });
 
       - name: Move board card to Development
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         continue-on-error: true
         uses: actions/github-script@v8
         with:

--- a/templates/.github/workflows/pdlc-health-check.yml
+++ b/templates/.github/workflows/pdlc-health-check.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 8 * * 1' # Every Monday at 8am
 
 env:
-  PROJECT_ID: "{{PROJECT_ID}}"
+  PROJECT_ID: ${{ vars.PROJECT_ID }}
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
   STATUS_BRAINSTORMING: "{{ID_BRAINSTORMING}}"
   STATUS_DETAILING: "{{ID_DETAILING}}"
@@ -26,7 +26,7 @@ jobs:
       issues: write
     steps:
       - name: Validate Board Configuration
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}

--- a/templates/.github/workflows/project-automation.yml
+++ b/templates/.github/workflows/project-automation.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled, edited, closed]
 
 env:
-  PROJECT_ID: "{{PROJECT_ID}}"
+  PROJECT_ID: ${{ vars.PROJECT_ID }}
   STATUS_FIELD_ID: "{{STATUS_FIELD_ID}}"
   STATUS_IDEA: "{{ID_IDEA}}"
   STATUS_BRAINSTORMING: "{{ID_BRAINSTORMING}}"
@@ -30,7 +30,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Detect Label and Move Issue
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Check spec markers and swap labels
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Move issue to Idea
-  #       if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+  #       if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
   #       uses: actions/github-script@v8
   #       with:
   #         github-token: ${{ env.PROJECT_TOKEN }}
@@ -179,7 +179,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Move linked issue to Testing
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -233,7 +233,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Move linked issue to Code Review / PR
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -281,7 +281,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Swap PR labels
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}
@@ -300,7 +300,7 @@ jobs:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
       - name: Move issue to Production
-        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '{{PROJECT_ID}}' }}
+        if: ${{ env.PROJECT_TOKEN != '' && env.PROJECT_ID != '' }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.PROJECT_TOKEN }}

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -30,3 +30,48 @@ describe('buildFullClaudeContent', () => {
     assert.ok(result.includes('## Extra'));
   });
 });
+
+describe('setActionsVariable', () => {
+  it('calls PATCH first', () => {
+    const calls = [];
+    const execFn = (cmd, args) => { calls.push(args); };
+    const { setActionsVariable } = require('../bin/cli.js');
+    setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].includes('--method'));
+    assert.ok(calls[0].includes('PATCH'));
+    assert.ok(calls[0].some(a => a.includes('PROJECT_ID')));
+  });
+
+  it('falls back to POST on 404', () => {
+    const calls = [];
+    let callCount = 0;
+    const execFn = (cmd, args) => {
+      calls.push([...args]);
+      callCount++;
+      if (callCount === 1) {
+        const err = new Error('Not Found');
+        err.stderr = Buffer.from('Not Found');
+        throw err;
+      }
+    };
+    const { setActionsVariable } = require('../bin/cli.js');
+    setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
+    assert.equal(calls.length, 2);
+    assert.ok(calls[0].includes('PATCH'));
+    assert.ok(calls[1].includes('POST'));
+  });
+
+  it('throws on 403', () => {
+    const execFn = () => {
+      const err = new Error('Forbidden');
+      err.stderr = Buffer.from('Forbidden');
+      throw err;
+    };
+    const { setActionsVariable } = require('../bin/cli.js');
+    assert.throws(
+      () => setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn),
+      /Forbidden/
+    );
+  });
+});

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -34,7 +34,7 @@ describe('buildFullClaudeContent', () => {
 describe('setActionsVariable', () => {
   it('calls PATCH first', () => {
     const calls = [];
-    const execFn = (cmd, args) => { calls.push([...args]); };
+    const execFn = (cmd, args, _opts) => { calls.push([...args]); };
     const { setActionsVariable } = require('../bin/cli.js');
     setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
     assert.equal(calls.length, 1);
@@ -47,7 +47,7 @@ describe('setActionsVariable', () => {
   it('falls back to POST on 404', () => {
     const calls = [];
     let callCount = 0;
-    const execFn = (cmd, args) => {
+    const execFn = (cmd, args, _opts) => {
       calls.push([...args]);
       callCount++;
       if (callCount === 1) {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -34,13 +34,14 @@ describe('buildFullClaudeContent', () => {
 describe('setActionsVariable', () => {
   it('calls PATCH first', () => {
     const calls = [];
-    const execFn = (cmd, args) => { calls.push(args); };
+    const execFn = (cmd, args) => { calls.push([...args]); };
     const { setActionsVariable } = require('../bin/cli.js');
     setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
     assert.equal(calls.length, 1);
     assert.ok(calls[0].includes('--method'));
     assert.ok(calls[0].includes('PATCH'));
     assert.ok(calls[0].some(a => a.includes('PROJECT_ID')));
+    assert.ok(calls[0].some(a => a.includes('PVT_abc')));
   });
 
   it('falls back to POST on 404', () => {
@@ -59,7 +60,9 @@ describe('setActionsVariable', () => {
     setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn);
     assert.equal(calls.length, 2);
     assert.ok(calls[0].includes('PATCH'));
+    assert.ok(calls[0].some(a => a.includes('PVT_abc')));
     assert.ok(calls[1].includes('POST'));
+    assert.ok(calls[1].some(a => a.includes('PVT_abc')));
   });
 
   it('throws on 403', () => {


### PR DESCRIPTION
## Summary

- Replace `{{PROJECT_ID}}` hardcoding in 4 workflow templates with `${{ vars.PROJECT_ID }}` (sources from GitHub Actions Variable at runtime)
- Add `setActionsVariable(repo, name, value, execFn)` helper in `bin/cli.js` — PATCH-first upsert with non-fatal 403 fallback
- Wire `setActionsVariable` into both `runFullSetup` (create) and `runUpgradeToAgentic` (lite→full upgrade) after board creation
- Remove `{{PROJECT_ID}}` YAML substitution from `scaffoldFullTemplates`; all other substitutions preserved

## Why

New installs were silently broken: `vars.PROJECT_ID` was never set, so `resolve-ids` emitted warnings and all card-moving jobs were no-ops.

## Test Plan

- [ ] 9/9 unit tests pass (`npm test`)
- [ ] `grep -rn "{{PROJECT_ID}}" templates/.github/workflows/` returns no output
- [ ] After `npx create-agentic-pdlc` on a new repo: `vars.PROJECT_ID` visible in repo Settings → Secrets and variables → Variables
- [ ] Board automation moves cards correctly without any YAML edits

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PROJECT_ID is now set as a GitHub Actions Variable during install/upgrade.
  * Workflow templates now source PROJECT_ID from GitHub Actions Variables instead of a literal placeholder.
* **Documentation**
  * Added implementation plan and design spec describing the variable-driven workflow approach.
* **Tests**
  * Added tests validating the variable-setting behavior, including patch-then-create fallback and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->