### PR TITLE
fix(agent-trigger): rename PROJECT_PAT to PROJECT_TOKEN

### DIFF
--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -58,22 +58,22 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    - **CLAUDE.md:** If `.agentic-pdlc/templates/CLAUDE.md` exists and `CLAUDE.md` does not yet exist at the project root, write it — replacing only `{{PROJECT_NAME}}` with the project name. Skip if CLAUDE.md already exists (never downgrade).
    - **Lite profile:** If `cli-context.json` has `"profile": "lite"`, skip steps that reference `docs/pdlc.md`, `project-automation.yml`, `agent-trigger.yml`, and `pdlc-health-check.yml` — these are not installed in lite.
 6. Offer to run the `gh` commands for labels (`spec:approved`, `pr:in-review`, `pr:approved`, `architecture-violation`).
-7. **`PROJECT_PAT` secret (required for board automation):**
+7. **`PROJECT_TOKEN` secret (required for board automation):**
 
    Read `patAutoSet` from `.agentic-pdlc/cli-context.json`:
 
-   **If `patAutoSet === true`:** The CLI already configured this secret automatically. Print `✅ PROJECT_PAT is configured.` and continue to Step 8 — do not ask the user anything.
+   **If `patAutoSet === true`:** The CLI already configured this secret automatically. Print `✅ PROJECT_TOKEN is configured.` and continue to Step 8 — do not ask the user anything.
 
    **If `patAutoSet === false` (org repo):** Show the block below and wait for the user to reply "done" or "secret set" before continuing:
 
-   > Your repo is in an organization. For security, `PROJECT_PAT` must be a dedicated PAT (not your personal OAuth token). Without it, all board card movements in CI will silently skip — no error surfaced.
+   > Your repo is in an organization. For security, `PROJECT_TOKEN` must be a dedicated PAT (not your personal OAuth token). Without it, all board card movements in CI will silently skip — no error surfaced.
    >
    > 1. Open: **github.com/settings/tokens** → *Generate new token (classic)*
-   > 2. Name: `PROJECT_PAT — <repo-name>`
+   > 2. Name: `PROJECT_TOKEN — <repo-name>`
    > 3. Select scopes: ✅ `repo` + ✅ `project`
    > 4. Copy the token, then run:
    >    ```
-   >    gh secret set PROJECT_PAT --body "<your-token>" --repo <owner>/<repo>
+   >    gh secret set PROJECT_TOKEN --body "<your-token>" --repo <owner>/<repo>
    >    ```
    > 5. Reply **"done"** when finished.
 8. **IMPORTANT:** Delete the setup prompt file by running exactly:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -568,21 +568,21 @@ async function runFullSetup() {
     }
   }
 
-  // Auto-provision PROJECT_PAT for personal repos
+  // Auto-provision PROJECT_TOKEN for personal repos
   let patAutoSet = false;
   if (projectId && !isOrg) {
     try {
       const tokenOut = execFileSync('gh', ['auth', 'token'], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' }).trim();
       if (tokenOut) {
-        execFileSync('gh', ['secret', 'set', 'PROJECT_PAT', '--body', tokenOut, '--repo', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
+        execFileSync('gh', ['secret', 'set', 'PROJECT_TOKEN', '--body', tokenOut, '--repo', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
         patAutoSet = true;
-        console.log(`\n${green}✅ PROJECT_PAT secret set automatically (uses your gh OAuth token).${reset}`);
+        console.log(`\n${green}✅ PROJECT_TOKEN secret set automatically (uses your gh OAuth token).${reset}`);
       }
     } catch (err) {
-      console.log(`\n${yellow}⚠️  Could not auto-set PROJECT_PAT. Agent will guide manual setup.${reset}`);
+      console.log(`\n${yellow}⚠️  Could not auto-set PROJECT_TOKEN. Agent will guide manual setup.${reset}`);
     }
   } else if (projectId && isOrg) {
-    console.log(`\n${yellow}ℹ️  Org repo detected — PROJECT_PAT will require manual setup for security.${reset}`);
+    console.log(`\n${yellow}ℹ️  Org repo detected — PROJECT_TOKEN will require manual setup for security.${reset}`);
   }
 
   // Set PROJECT_ID as GitHub Actions Variable
@@ -1030,20 +1030,20 @@ async function runUpgradeToAgentic() {
     }
   }
 
-  // Auto-provision PROJECT_PAT for personal repos
+  // Auto-provision PROJECT_TOKEN for personal repos
   let patAutoSet = false;
   if (projectId && !isOrg) {
     try {
       const tokenOut = execFileSync('gh', ['auth', 'token'],
         { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' }).trim();
       if (tokenOut) {
-        execFileSync('gh', ['secret', 'set', 'PROJECT_PAT', '--body', tokenOut, '--repo', repo],
+        execFileSync('gh', ['secret', 'set', 'PROJECT_TOKEN', '--body', tokenOut, '--repo', repo],
           { stdio: ['ignore', 'pipe', 'pipe'] });
         patAutoSet = true;
-        console.log(`\n${green}✅ PROJECT_PAT secret set automatically (uses your gh OAuth token).${reset}`);
+        console.log(`\n${green}✅ PROJECT_TOKEN secret set automatically (uses your gh OAuth token).${reset}`);
       }
     } catch (_) {
-      console.log(`\n${yellow}⚠️  Could not auto-set PROJECT_PAT. Agent will guide manual setup.${reset}`);
+      console.log(`\n${yellow}⚠️  Could not auto-set PROJECT_TOKEN. Agent will guide manual setup.${reset}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- `cli.js` was setting the secret as `PROJECT_PAT`; `agent-trigger.yml` reads `PROJECT_TOKEN` (canonical per AGENTS.md)
- Mismatch → Jules label step silently skipped on every `spec:approved` event → Jules never activated
- Renamed all occurrences in `bin/cli.js` and `adapters/claude-code/skill.md`

## Test plan

- [ ] All 9 existing tests pass (`node --test tests/cli.test.js`)
- [ ] No `PROJECT_PAT` references remain in `bin/cli.js` or `adapters/claude-code/skill.md`
- [ ] `templates/.github/workflows/agent-trigger.yml` step "Add agent label via PAT" reads `PROJECT_TOKEN` (no change needed — already correct)

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated board automation secret configuration to use `PROJECT_TOKEN` instead of `PROJECT_PAT` in setup and upgrade workflows. Personal repository setup now auto-configures the secret; organization repository users will need to manually set the new secret name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->