### PR TITLE
feat(cli): add scaffold isolation tests and lite upgrade hint

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -60,6 +60,7 @@ const i18n = {
   cursor_rules_written: t('✅ Default cursor rules written to .cursorrules', '✅ Regras padrão do cursor salvas em .cursorrules', '✅ Reglas por defecto de cursor guardadas en .cursorrules'),
   setup_done: t('🎉 All set! Continue the setup with your agent:', '🎉 Aqui tá pronto! Continue o setup com o seu agente:', '🎉 ¡Listo! Continúa el setup con tu agente:'),
   setup_done_hint: t('>>> Tell it to read and execute the .agentic-setup.md file!', '>>> Diga a ele para ler e executar o arquivo .agentic-setup.md!', '>>> Dile que lea y ejecute el archivo .agentic-setup.md!'),
+  upgrade_hint: t('💡 To add the full board + multi-agent automation later: npx create-agentic-pdlc --upgrade-to-agentic', '💡 Para adicionar o board completo + automação multi-agente mais tarde: npx create-agentic-pdlc --upgrade-to-agentic', '💡 Para agregar el tablero completo + automatización multi-agente más tarde: npx create-agentic-pdlc --upgrade-to-agentic'),
   update_title: t('agentic-pdlc — Agent Configuration Status', 'agentic-pdlc — Status de Configuração dos Agentes', 'agentic-pdlc — Estado de Configuración de Agentes'),
   update_no_context: t('❌ No .agentic-pdlc/cli-context.json found. Run npx create-agentic-pdlc first.', '❌ Arquivo .agentic-pdlc/cli-context.json não encontrado. Rode npx create-agentic-pdlc primeiro.', '❌ Archivo .agentic-pdlc/cli-context.json no encontrado. Ejecuta npx create-agentic-pdlc primero.'),
   update_all_ok: t('All agents configured!', 'Todos os agentes configurados!', '¡Todos los agentes configurados!'),
@@ -891,7 +892,7 @@ async function runLiteSetup() {
   });
 
   copyAdapterFiles(agent, sourceDir, targetDir);
-  console.log(`${cyan}💡 To add the full board + multi-agent automation later: npx create-agentic-pdlc --upgrade-to-agentic${reset}`);
+  console.log(`${cyan}${i18n.upgrade_hint}${reset}`);
 
   rl.close();
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -832,7 +832,7 @@ function resolveMode(args) {
 }
 
 // Export for testing
-if (typeof module !== 'undefined') module.exports = { resolveMode, setActionsVariable };
+if (typeof module !== 'undefined') module.exports = { resolveMode, setActionsVariable, scaffoldLiteTemplates, scaffoldFullTemplates };
 
 // ─── runLiteSetup ─────────────────────────────────────────────────────────────
 
@@ -891,6 +891,7 @@ async function runLiteSetup() {
   });
 
   copyAdapterFiles(agent, sourceDir, targetDir);
+  console.log(`${cyan}💡 To add the full board + multi-agent automation later: npx create-agentic-pdlc --upgrade-to-agentic${reset}`);
 
   rl.close();
 }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,5 +1,9 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
 
 const { resolveMode } = require('../bin/cli.js');
 
@@ -76,5 +80,39 @@ describe('setActionsVariable', () => {
       () => setActionsVariable('owner/repo', 'PROJECT_ID', 'PVT_abc', execFn),
       /Forbidden/
     );
+  });
+});
+
+describe('scaffoldLiteTemplates', () => {
+  it('copies CLAUDE.md and AGENTS.md but excludes .github/workflows', () => {
+    const { scaffoldLiteTemplates } = require('../bin/cli.js');
+    const src = path.join(__dirname, '..');
+    const tmp = path.join(os.tmpdir(), `pdlc-lite-${crypto.randomBytes(4).toString('hex')}`);
+    try {
+      scaffoldLiteTemplates(src, tmp);
+      const base = path.join(tmp, '.agentic-pdlc', 'templates');
+      assert.ok(fs.existsSync(path.join(base, 'CLAUDE.md')), 'CLAUDE.md should exist');
+      assert.ok(fs.existsSync(path.join(base, 'AGENTS.md')), 'AGENTS.md should exist');
+      assert.ok(!fs.existsSync(path.join(base, '.github', 'workflows')), '.github/workflows must not exist in lite');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('scaffoldFullTemplates', () => {
+  it('copies .github/workflows with at least one yml file', () => {
+    const { scaffoldFullTemplates } = require('../bin/cli.js');
+    const src = path.join(__dirname, '..');
+    const tmp = path.join(os.tmpdir(), `pdlc-full-${crypto.randomBytes(4).toString('hex')}`);
+    try {
+      scaffoldFullTemplates(src, tmp, null, null, {}, 'owner', 'repo');
+      const wfDir = path.join(tmp, '.agentic-pdlc', 'templates', '.github', 'workflows');
+      assert.ok(fs.existsSync(wfDir), '.github/workflows should exist in full');
+      const ymls = fs.readdirSync(wfDir).filter(f => f.endsWith('.yml'));
+      assert.ok(ymls.length > 0, 'should contain at least one .yml file');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Exports `scaffoldLiteTemplates` and `scaffoldFullTemplates` from `bin/cli.js` for testability
- Adds test suite verifying lite profile does NOT include `.github/workflows` and full profile DOES
- Adds `--upgrade-to-agentic` hint to lite post-install output for discoverability

## Test plan

- [ ] `node --test tests/cli.test.js` → 11/11 pass
- [ ] Lite scaffold test: `CLAUDE.md` + `AGENTS.md` present, `.github/workflows` absent
- [ ] Full scaffold test: `.github/workflows` present with at least one `.yml`

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now exposes template scaffolding helpers for both lite and full setups.
  * Lite setup displays an upgrade hint guiding users to add full board and multi-agent automation later.

* **Tests**
  * Added test coverage for template scaffolding behavior, including file copying and workflow creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->