### PR TITLE
chore(coderabbit): assertive profile + bin/cli.js i18n instruction

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,6 @@
 language: "en-US"
 reviews:
-  profile: "chill"
+  profile: "assertive"
   request_changes_workflow: false
   high_level_summary: true
   poem: false
@@ -10,6 +10,12 @@ reviews:
     base_branches:
       - main
   path_instructions:
+    - path: "bin/cli.js"
+      instructions: >
+        All user-facing console.log strings must use the t() translation helper.
+        New strings must be added to the i18n object and referenced via i18n.key_name.
+        Flag any hardcoded English-only string in console output as a violation of
+        the project's i18n pattern.
     - path: ".github/workflows/**"
       instructions: >
         Pay close attention to GitHub Actions syntax correctness, trigger


### PR DESCRIPTION
## Summary

- `profile: chill` → `profile: assertive` — full file context analysis, catches convention violations not visible in diff alone
- Added `path_instructions` for `bin/cli.js` to enforce the `t()` i18n pattern explicitly

## Motivation

PR #188 had a hardcoded English string that Gemini caught but CodeRabbit missed. Root cause: CHILL profile + diff-only analysis. Assertive profile reads the full file and detects inconsistencies against established patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration and tooling standards for CLI development.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->