### PR TITLE
fix(cli): skip branch protection for private repos with clear message

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -104,6 +104,11 @@ const i18n = {
     '\n⚠️  Dono ou nome do repositório ausente em cli-context.json. Criação automática de labels será pulada.',
     '\n⚠️  Propietario o nombre del repositorio faltante en cli-context.json. Se omitirá la creación automática de etiquetas.'
   ),
+  protection_private_repo: t(
+    '⚠️  GitHub allows Branch Protection only for public repos (or a paid plan).\n     👌  Don\'t worry, the workflow still runs smoothly, but PRs can be merged without approval.',
+    '⚠️  O GitHub permite Branch Protection apenas para repos públicos (ou plano pago).\n     👌  Sem problemas, o workflow continua funcionando normalmente, mas PRs podem ser mergeados sem aprovação.',
+    '⚠️  GitHub permite Branch Protection solo para repos públicos (o un plan de pago).\n     👌  No te preocupes, el workflow sigue funcionando normalmente, pero los PRs pueden fusionarse sin aprobación.'
+  ),
 };
 
 const cyan = '\x1b[36m';
@@ -244,10 +249,17 @@ function installHook(sourceDir, targetDir) {
 async function setBranchProtection(repo, requiredChecks) {
   console.log(`\n${cyan}${i18n.configuring_protection}${reset}`);
   try {
-    const defaultBranch = execFileSync(
-      'gh', ['api', `repos/${repo}`, '--jq', '.default_branch'],
+    const repoInfo = JSON.parse(execFileSync(
+      'gh', ['api', `repos/${repo}`, '--jq', '{private: .private, default_branch: .default_branch}'],
       { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf8' }
-    ).trim() || 'main';
+    ).trim());
+
+    if (repoInfo.private) {
+      console.log(`  ${yellow}${i18n.protection_private_repo}${reset}`);
+      return;
+    }
+
+    const defaultBranch = repoInfo.default_branch || 'main';
 
     const protectionPayload = JSON.stringify({
       required_status_checks: { strict: false, contexts: requiredChecks },


### PR DESCRIPTION
## Summary

- Check repo visibility before attempting branch protection — private repos on the free GitHub plan cannot enforce rules, so the attempt is skipped
- Single API call fetches both `.private` and `.default_branch` (previously two separate calls)
- Informative message with EN/PT/ES i18n instead of a confusing failure

Closes #192

## Test Plan

- [ ] Private repo → step 3/3 prints the informative message, no API call to `/branches/.../protection`
- [ ] Public repo → branch protection applied as before
- [ ] API failure → falls to existing `catch` → shows `protection_warn` unchanged
- [ ] `npm test` — 9/9 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning message for users attempting to set branch protection on private repositories (unavailable unless on a paid plan).

* **Bug Fixes**
  * Improved branch protection setup to check repository privacy status upfront and handle private repositories gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->