### PR TITLE
feat(templates): make AGENTS.md the complete behavioral contract

### DIFF
--- a/adapters/hooks/pdlc-stage-gate.sh
+++ b/adapters/hooks/pdlc-stage-gate.sh
@@ -26,7 +26,7 @@ fi
 
 LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
 
-if echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:approval" || echo "$LABELS" | grep -qw "stage:development" || echo "$LABELS" | grep -qw "stage:testing" || echo "$LABELS" | grep -qw "human-approved"; then
+if echo "$LABELS" | grep -qw "spec:approved" || echo "$LABELS" | grep -qw "stage:development" || echo "$LABELS" | grep -qw "human-approved"; then
   echo "✅ PDLC: Issue #$ISSUE_NUM approved — gate passed."
   exit 0
 fi
@@ -34,6 +34,6 @@ fi
 STAGE=$(echo "$LABELS" | tr ' ' '\n' | grep "^stage:" | head -1 || echo "none")
 echo "❌ PDLC Stage Gate: Issue #$ISSUE_NUM is not approved."
 echo "   Current stage: $STAGE"
-echo "   Required: stage:approval OR spec:approved OR stage:development OR stage:testing OR human-approved label on the issue."
+echo "   Required: spec:approved OR stage:development OR human-approved label on the issue."
 echo "   Emergency bypass: rename branch to hotfix/<issue-number>-<description>."
 exit 1

--- a/templates/full/AGENTS.md
+++ b/templates/full/AGENTS.md
@@ -126,7 +126,7 @@ gh issue view <N> --json labels --jq '.labels[].name'
 
 If `spec:approved` is not present — stop. Go back to the issue, complete the spec, advance to `stage:approval`, and wait for the PM to add the label.
 
-> Claude Code enforces this automatically via a PreToolUse hook.
+> Claude Code enforces this automatically via a PreToolUse hook that allows `gh pr create` only when the issue has `spec:approved`, `stage:development`, or `human-approved`.
 > All other agents must enforce it manually — treat it as a hard constraint, not a guideline.
 
 ## Pipeline Updates

--- a/templates/full/AGENTS.md
+++ b/templates/full/AGENTS.md
@@ -111,6 +111,24 @@ sections (`## Problem`, `## Solution`, `## Acceptance Criteria`, `## Edge Cases`
 `stage:brainstorming` and `stage:detailing`. One label event eliminates the
 race condition that causes the project board to land on the wrong column.
 
+## ⛔ NEVER Open a PR Without `spec:approved`
+
+**This is the most important rule in this file.**
+
+Opening a PR without `spec:approved` on the linked issue bypasses the human review gate and breaks the PDLC contract with your team.
+
+**Before running `gh pr create`, always verify:**
+
+```bash
+gh issue view <N> --json labels --jq '.labels[].name'
+# Must include: spec:approved
+```
+
+If `spec:approved` is not present — stop. Go back to the issue, complete the spec, advance to `stage:approval`, and wait for the PM to add the label.
+
+> Claude Code enforces this automatically via a PreToolUse hook.
+> All other agents must enforce it manually — treat it as a hard constraint, not a guideline.
+
 ## Pipeline Updates
 
 To add or configure optional agents (Jules, QA Agent, Sentinel) at any time:

--- a/templates/lite/AGENTS.md
+++ b/templates/lite/AGENTS.md
@@ -92,6 +92,24 @@ Automation checks the issue body for `## Acceptance Criteria` and `## Files to M
 
 **NEVER apply `spec:approved`, `stage:development`, or `qa:*`.** These are owned by the PM and automation.
 
+## ⛔ NEVER Open a PR Without `spec:approved`
+
+**This is the most important rule in this file.**
+
+Opening a PR without `spec:approved` on the linked issue bypasses the human review gate and breaks the PDLC contract with your team.
+
+**Before running `gh pr create`, always verify:**
+
+```bash
+gh issue view <N> --json labels --jq '.labels[].name'
+# Must include: spec:approved
+```
+
+If `spec:approved` is not present — stop. Go back to the issue, complete the spec, advance to `stage:approval`, and wait for the PM to add the label.
+
+> Claude Code enforces this automatically via a PreToolUse hook.
+> All other agents must enforce it manually — treat it as a hard constraint, not a guideline.
+
 ## Stage Transition Rules (non-negotiable)
 
 MUST apply `stage:brainstorming` immediately on starting work — before reading any code,

--- a/templates/lite/AGENTS.md
+++ b/templates/lite/AGENTS.md
@@ -107,7 +107,7 @@ gh issue view <N> --json labels --jq '.labels[].name'
 
 If `spec:approved` is not present — stop. Go back to the issue, complete the spec, advance to `stage:approval`, and wait for the PM to add the label.
 
-> Claude Code enforces this automatically via a PreToolUse hook.
+> Claude Code enforces this automatically via a PreToolUse hook that allows `gh pr create` only when the issue has `spec:approved`, `stage:development`, or `human-approved`.
 > All other agents must enforce it manually — treat it as a hard constraint, not a guideline.
 
 ## Stage Transition Rules (non-negotiable)

--- a/templates/lite/CLAUDE.md
+++ b/templates/lite/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ### Hook Enforcement
 
-A `PreToolUse` hook automatically blocks `gh pr create` if the linked issue lacks `spec:approved`.
+A `PreToolUse` hook blocks `gh pr create` unless the linked issue has `spec:approved`, `stage:development`, or `human-approved`.
 If blocked: check the issue labels and advance the spec before retrying.
 
 ### Invariants

--- a/templates/lite/CLAUDE.md
+++ b/templates/lite/CLAUDE.md
@@ -1,44 +1,14 @@
-# {{PROJECT_NAME}}
+# {{PROJECT_NAME}} — Claude Code Instructions
 
-**What it is:** {{PROJECT_DESCRIPTION}}
+> **The full behavioral contract (stage gates, workflow, spec format, label rules, PR gate) is in `AGENTS.md`. Read it before starting any work.**
 
-## Non-Negotiable Invariants
+## Claude Code-Specific
 
-1. **Minimum viable change** — implement exactly what the spec says. No refactoring beyond scope, no future-proofing, no abstractions for hypothetical needs.
-2. **Spec before code** — never edit files, create branches, or commit unless the linked issue has label `spec:approved` (set by PM only) or the branch starts with `hotfix/`.
+### Hook Enforcement
 
-## Stage Gate
+A `PreToolUse` hook automatically blocks `gh pr create` if the linked issue lacks `spec:approved`.
+If blocked: check the issue labels and advance the spec before retrying.
 
-Three labels gate every issue:
+### Invariants
 
-| Label | Who sets it | What it unlocks |
-|---|---|---|
-| `stage:brainstorming` | Agent (first action) | Reading code + presenting options |
-| `stage:approval` | Agent (after spec is written) | Signals spec is ready for PM review |
-| `spec:approved` | **PM only** | Clears agent to implement |
-
-**NEVER apply `spec:approved`.** The PM sets it after reviewing the spec in the issue body. Applying it triggers irreversible automation.
-
-## Workflow
-
-1. Apply `stage:brainstorming` immediately — before reading code or invoking any tool.
-2. Read the issue. Present problem summary + 2–3 solution options. **Stop and wait for PM to choose.**
-3. Once PM selects an approach, write the complete spec into the issue body (`gh issue edit <N> --body "..."`). Advance to `stage:approval`.
-4. **Stop.** Wait for PM to add `spec:approved`.
-5. After `spec:approved`: create branch, implement minimum viable change, open PR with `Closes #N`.
-
-## Hook Behavior
-
-A `PreToolUse` hook blocks `gh pr create` unless:
-- The linked issue has `spec:approved`, **or**
-- The branch name starts with `hotfix/`
-
-If blocked: check the issue labels before retrying.
-
-## What NOT to Do
-
-- Never commit to `main` directly.
-- Never open a PR without `spec:approved` on the linked issue.
-- Never implement beyond the immediate scope of the spec.
-- Never add abstractions, error handling, or features for hypothetical future needs.
-- Never apply `spec:approved`, `stage:development`, or `qa:*` — these are PM/automation only.
+{{EXTRA_PATTERNS}}


### PR DESCRIPTION
## Summary

- Add `⛔ NEVER Open a PR Without spec:approved` section to both `templates/full/AGENTS.md` and `templates/lite/AGENTS.md` — includes verification command, stop instruction, and explicit note that non-Claude agents must enforce this manually
- Slim `templates/lite/CLAUDE.md` to a thin Claude Code adapter: pointer to `AGENTS.md` + hook enforcement note only
- Any agent (Gemini, Copilot, Cursor, or future) reading `AGENTS.md` now gets the full PDLC contract without relying on `CLAUDE.md`

Closes #196

## Test Plan

- [ ] `AGENTS.md` (lite + full) standalone — a Gemini dev reading only this file knows: stage gates, workflow, spec format, PR gate with verification command
- [ ] `CLAUDE.md` (lite) no longer duplicates the behavioral contract — points to `AGENTS.md`
- [ ] No contradictions between the two files
- [ ] `npm test` — 11/11 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a hard rule: PRs must not be opened unless the linked issue has a spec:approved label
  * Added a verification checklist (GitHub CLI) to confirm the label and guidance to pause and complete the spec if missing
  * Consolidated agent contract docs and streamlined the Claude-specific guidance

* **Behavior**
  * Stage-gate approval now accepts spec:approved, stage:development, or human-approved and updates the failure message accordingly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->