### PR TITLE
fix(automation): map spec:approved to Development column

### DIFF
--- a/scripts/derive-column.js
+++ b/scripts/derive-column.js
@@ -4,6 +4,7 @@
 const LABEL_PRIORITY = [
   { label: 'pr:in-review',        column: 'code_review_pr' },
   { label: 'pr:approved',         column: 'code_review_pr' },
+  { label: 'spec:approved',        column: 'development' },
   { label: 'stage:development',   column: 'development' },
   { label: 'stage:approval',      column: 'approval' },
   { label: 'stage:detailing',     column: 'detailing' },


### PR DESCRIPTION
## Summary

When the PM adds `spec:approved`, the issue still has `stage:approval`. `classifyItem` was matching `stage:approval` first and moving the card to Approval instead of Development.

Added `{ label: 'spec:approved', column: 'development' }` above `stage:approval` in `LABEL_PRIORITY` — when both labels coexist, `spec:approved` wins.

Fix applies to both the event dispatcher and the reconciliation cron since both consume `derive-column.js`.

Closes #199

## Test Plan

- [ ] Adding `spec:approved` to an issue with `stage:approval` moves card to Development
- [ ] `classifyItem(['stage:approval', 'spec:approved'])` returns `'development'`
- [ ] Existing classifications unchanged
- [ ] `npm test` — 11/11 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal label classification rules to enhance workflow item organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->