### PR TITLE
feat(cli): scaffold GEMINI.md for Gemini CLI users

### DIFF
--- a/adapters/gemini/gemini.md
+++ b/adapters/gemini/gemini.md
@@ -1,0 +1,22 @@
+# {{PROJECT_NAME}} — Gemini CLI Instructions
+
+> **The full behavioral contract (stage gates, workflow, spec format, label rules, PR gate) is in `AGENTS.md`. Read it before starting any work.**
+
+## Gemini CLI-Specific
+
+### Enforcement Note
+
+Gemini CLI has no PreToolUse hook. The `spec:approved` gate must be enforced manually.
+
+Before running `gh pr create`, always verify:
+
+```bash
+gh issue view <N> --json labels --jq '.labels[].name'
+# Must include: spec:approved
+```
+
+If `spec:approved` is not present — stop. Complete the spec, advance to `stage:approval`, and wait for the PM.
+
+### Invariants
+
+{{EXTRA_PATTERNS}}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -58,6 +58,8 @@ const i18n = {
   setup_written: t('✅ Setup agent profile written to .agentic-setup.md\n', '✅ Perfil de setup do agente salvo em .agentic-setup.md\n', '✅ Perfil de configuración del agente guardado en .agentic-setup.md\n'),
   missing_claude: t('❌ Could not find instruction file at ', '❌ Não foi possível encontrar o arquivo de instrução em ', '❌ No se pudo encontrar el archivo de instrucción en '),
   cursor_rules_written: t('✅ Default cursor rules written to .cursorrules', '✅ Regras padrão do cursor salvas em .cursorrules', '✅ Reglas por defecto de cursor guardadas en .cursorrules'),
+  gemini_md_written: t('✅ GEMINI.md written to project root', '✅ GEMINI.md escrito na raiz do projeto', '✅ GEMINI.md escrito en la raíz del proyecto'),
+  gemini_done_hint: t('>>> Tell it to read GEMINI.md and AGENTS.md to start!', '>>> Diga a ele para ler GEMINI.md e AGENTS.md para começar!', '>>> Dile que lea GEMINI.md y AGENTS.md para empezar!'),
   setup_done: t('🎉 All set! Continue the setup with your agent:', '🎉 Aqui tá pronto! Continue o setup com o seu agente:', '🎉 ¡Listo! Continúa el setup con tu agente:'),
   setup_done_hint: t('>>> Tell it to read and execute the .agentic-setup.md file!', '>>> Diga a ele para ler e executar o arquivo .agentic-setup.md!', '>>> Dile que lea y ejecute el archivo .agentic-setup.md!'),
   upgrade_hint: t('💡 To add the full board + multi-agent automation later: npx create-agentic-pdlc --upgrade-to-agentic', '💡 Para adicionar o board completo + automação multi-agente mais tarde: npx create-agentic-pdlc --upgrade-to-agentic', '💡 Para agregar el tablero completo + automatización multi-agente más tarde: npx create-agentic-pdlc --upgrade-to-agentic'),
@@ -159,9 +161,9 @@ function copyDirSync(src, dest) {
   }
 }
 
-function printSetupDone() {
+function printSetupDone(hint) {
   const line1 = i18n.setup_done;
-  const line2 = i18n.setup_done_hint;
+  const line2 = hint || i18n.setup_done_hint;
   const sep = '='.repeat(Math.max(line1.length, line2.length));
   console.log(`\n${green}${sep}${reset}`);
   console.log(`${green}${line1}${reset}`);
@@ -283,6 +285,7 @@ async function setBranchProtection(repo, requiredChecks) {
 function copyAdapterFiles(agent, sourceDir, targetDir) {
   const claudeSetupSrc = path.join(sourceDir, 'adapters', 'claude-code', 'skill.md');
   const cursorSetupSrc = path.join(sourceDir, 'adapters', 'cursor',     'rules.md');
+  const geminiSetupSrc = path.join(sourceDir, 'adapters', 'gemini',     'gemini.md');
 
   if (agent === 'cursor') {
     if (fs.existsSync(cursorSetupSrc)) {
@@ -290,6 +293,14 @@ function copyAdapterFiles(agent, sourceDir, targetDir) {
       console.log(`${i18n.cursor_rules_written}`);
     }
   }
+
+  if (agent === 'gemini' && fs.existsSync(geminiSetupSrc)) {
+    fs.copyFileSync(geminiSetupSrc, path.join(targetDir, 'GEMINI.md'));
+    console.log(`${i18n.gemini_md_written}`);
+    printSetupDone(i18n.gemini_done_hint);
+    return;
+  }
+
   if (fs.existsSync(claudeSetupSrc)) {
     fs.copyFileSync(claudeSetupSrc, path.join(targetDir, '.agentic-setup.md'));
     console.log(`${i18n.setup_written}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -295,7 +295,11 @@ function copyAdapterFiles(agent, sourceDir, targetDir) {
   }
 
   if (agent === 'gemini' && fs.existsSync(geminiSetupSrc)) {
-    fs.copyFileSync(geminiSetupSrc, path.join(targetDir, 'GEMINI.md'));
+    const projectName = path.basename(targetDir).toUpperCase();
+    let geminiContent = fs.readFileSync(geminiSetupSrc, 'utf8');
+    geminiContent = geminiContent.replace(/\{\{PROJECT_NAME\}\}/g, projectName);
+    geminiContent = geminiContent.replace(/\{\{EXTRA_PATTERNS\}\}/g, '');
+    fs.writeFileSync(path.join(targetDir, 'GEMINI.md'), geminiContent, 'utf8');
     console.log(`${i18n.gemini_md_written}`);
     printSetupDone(i18n.gemini_done_hint);
     return;


### PR DESCRIPTION
## Summary

- Add `adapters/gemini/gemini.md` — thin adapter template: pointer to `AGENTS.md` + Gemini-specific enforcement note (no PreToolUse hook, manual `spec:approved` gate required)
- When user selects `gemini` at install: write `GEMINI.md` to project root, skip `.agentic-setup.md` (Claude Code skill, useless to Gemini)
- Add i18n keys `gemini_md_written` and `gemini_done_hint` (EN/PT/ES)
- `printSetupDone` accepts optional hint override for agent-specific message
- Claude and Cursor flows unchanged; other agents still get `.agentic-setup.md` as fallback

Closes #198

## Test Plan

- [ ] `npx create-agentic-pdlc` with agent = `gemini` → `GEMINI.md` written, no `.agentic-setup.md`
- [ ] `GEMINI.md` content: pointer to `AGENTS.md` + enforcement note
- [ ] Claude flow unchanged
- [ ] Cursor flow unchanged
- [ ] `npm test` — 11/11 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided Gemini adapter setup in the CLI, which writes a project-specific Gemini instruction file and shows targeted follow-up hints.

* **Documentation**
  * Added a user-facing Gemini instructions document with setup steps, a manual approval/check reminder, and guidance on advancing the spec/stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->