### PR TITLE
fix(cli): treat 'antigravity' agent as Gemini install (GEMINI.md)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -294,7 +294,7 @@ function copyAdapterFiles(agent, sourceDir, targetDir) {
     }
   }
 
-  if (agent === 'gemini' && fs.existsSync(geminiSetupSrc)) {
+  if ((agent === 'gemini' || agent === 'antigravity') && fs.existsSync(geminiSetupSrc)) {
     const projectName = path.basename(targetDir).toUpperCase();
     let geminiContent = fs.readFileSync(geminiSetupSrc, 'utf8');
     geminiContent = geminiContent.replace(/\{\{PROJECT_NAME\}\}/g, projectName);


### PR DESCRIPTION
## Summary

- Antigravity users were getting `.agentic-setup.md` (Claude fallback) instead of `GEMINI.md`
- Extended gemini branch in `copyAdapterFiles` to also match `agent === 'antigravity'`
- Single condition change; all placeholder substitution and completion messages unchanged

## Test plan

- [ ] Run CLI with `antigravity` → verify `GEMINI.md` written with substituted placeholders
- [ ] Run CLI with `gemini` → verify unchanged behavior
- [ ] Run CLI with `claude`/`cursor` → verify unchanged behavior

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the antigravity agent to use the GEMINI adapter template, matching existing behavior for the gemini agent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->