### PR TITLE
fix(cli): name Claude Code explicitly in adapter success message

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -128,7 +128,7 @@ const i18n = {
   templates_copied: t('✅ Templates copied to .agentic-pdlc/templates/', '✅ Templates copiados para .agentic-pdlc/templates/', '✅ Plantillas copiadas a .agentic-pdlc/templates/'),
   pdlc_prefilled: t('✅ Pre-filled pdlc.md with Project ID, Status Field ID, and Column Option IDs.', '✅ pdlc.md preenchido com Project ID, Status Field ID, e Column Option IDs.', '✅ pdlc.md completado con Project ID, Status Field ID y Column Option IDs.'),
   setup_written: t('✅ Setup agent profile written to .agentic-setup.md\n', '✅ Perfil de setup do agente salvo em .agentic-setup.md\n', '✅ Perfil de configuración del agente guardado en .agentic-setup.md\n'),
-  claude_setup_written: t('✅ .agentic-setup.md written for Claude Code\n', '✅ .agentic-setup.md escrito para Claude Code\n', '✅ .agentic-setup.md escrito para Claude Code\n'),
+  claude_setup_written: t('✅ .agentic-setup.md written for Claude Code', '✅ .agentic-setup.md escrito para Claude Code', '✅ .agentic-setup.md escrito para Claude Code'),
   missing_claude: t('⚠️ Claude Code adapter file not bundled — .agentic-setup.md skipped. Expected: ', '⚠️ Arquivo do adaptador Claude Code não encontrado — .agentic-setup.md ignorado. Esperado: ', '⚠️ Archivo del adaptador Claude Code no encontrado — .agentic-setup.md omitido. Esperado: '),
   cursor_rules_written: t('✅ Default cursor rules written to .cursorrules', '✅ Regras padrão do cursor salvas em .cursorrules', '✅ Reglas por defecto de cursor guardadas en .cursorrules'),
   gemini_md_written: t('✅ GEMINI.md written to project root', '✅ GEMINI.md escrito na raiz do projeto', '✅ GEMINI.md escrito en la raíz del proyecto'),
@@ -368,7 +368,7 @@ function copyAdapterFiles(agentChoice, sourceDir, targetDir) {
       fs.copyFileSync(claudeSetupSrc, path.join(targetDir, '.agentic-setup.md'));
       console.log(i18n.claude_setup_written);
     } else {
-      console.warn(`${i18n.missing_claude}${claudeSetupSrc}`);
+      console.warn(`${yellow}${i18n.missing_claude}${claudeSetupSrc}${reset}`);
     }
   }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -128,7 +128,8 @@ const i18n = {
   templates_copied: t('✅ Templates copied to .agentic-pdlc/templates/', '✅ Templates copiados para .agentic-pdlc/templates/', '✅ Plantillas copiadas a .agentic-pdlc/templates/'),
   pdlc_prefilled: t('✅ Pre-filled pdlc.md with Project ID, Status Field ID, and Column Option IDs.', '✅ pdlc.md preenchido com Project ID, Status Field ID, e Column Option IDs.', '✅ pdlc.md completado con Project ID, Status Field ID y Column Option IDs.'),
   setup_written: t('✅ Setup agent profile written to .agentic-setup.md\n', '✅ Perfil de setup do agente salvo em .agentic-setup.md\n', '✅ Perfil de configuración del agente guardado en .agentic-setup.md\n'),
-  missing_claude: t('❌ Could not find instruction file at ', '❌ Não foi possível encontrar o arquivo de instrução em ', '❌ No se pudo encontrar el archivo de instrucción en '),
+  claude_setup_written: t('✅ .agentic-setup.md written for Claude Code\n', '✅ .agentic-setup.md escrito para Claude Code\n', '✅ .agentic-setup.md escrito para Claude Code\n'),
+  missing_claude: t('⚠️ Claude Code adapter file not bundled — .agentic-setup.md skipped. Expected: ', '⚠️ Arquivo do adaptador Claude Code não encontrado — .agentic-setup.md ignorado. Esperado: ', '⚠️ Archivo del adaptador Claude Code no encontrado — .agentic-setup.md omitido. Esperado: '),
   cursor_rules_written: t('✅ Default cursor rules written to .cursorrules', '✅ Regras padrão do cursor salvas em .cursorrules', '✅ Reglas por defecto de cursor guardadas en .cursorrules'),
   gemini_md_written: t('✅ GEMINI.md written to project root', '✅ GEMINI.md escrito na raiz do projeto', '✅ GEMINI.md escrito en la raíz del proyecto'),
   gemini_done_hint: t('>>> Tell it to read GEMINI.md and AGENTS.md to start!', '>>> Diga a ele para ler GEMINI.md e AGENTS.md para começar!', '>>> Dile que lea GEMINI.md y AGENTS.md para empezar!'),
@@ -365,9 +366,9 @@ function copyAdapterFiles(agentChoice, sourceDir, targetDir) {
   function installClaude() {
     if (fs.existsSync(claudeSetupSrc)) {
       fs.copyFileSync(claudeSetupSrc, path.join(targetDir, '.agentic-setup.md'));
-      console.log(i18n.setup_written);
+      console.log(i18n.claude_setup_written);
     } else {
-      console.error(`${i18n.missing_claude}${claudeSetupSrc}`);
+      console.warn(`${i18n.missing_claude}${claudeSetupSrc}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add dedicated `claude_setup_written` i18n key with message `✅ .agentic-setup.md written for Claude Code` — consistent with `gemini_md_written` and `cursor_rules_written` format
- Update `missing_claude` message to clarify the adapter file was not bundled (not a permission failure)
- Demote missing-adapter log from `console.error` to `console.warn`

## Test Plan

- [ ] Run `npm test` — 16/16 pass, no regression on cursor/gemini paths
- [ ] Verify `installClaude()` success prints `✅ .agentic-setup.md written for Claude Code`
- [ ] Verify missing `skill.md` prints `⚠️ Claude Code adapter file not bundled — ...` as a warning, not an error

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a dedicated success message for the Claude Code adapter setup to make successful installs clearer.

* **Bug Fixes**
  * Clarified CLI messaging for missing Claude adapter: now logs a warning and indicates the optional setup doc was skipped rather than treating it as an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->