### PR TITLE
fix(cli): show error reason and manual steps when project link fails (#207)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -122,11 +122,9 @@ const i18n = {
   link_project_ok: t('✅ Project linked to repository.', '✅ Projeto vinculado ao repositório.', '✅ Proyecto vinculado al repositorio.'),
   link_project_warn: t('⚠️ Failed to link project to repository. Link it manually in GitHub Projects settings.', '⚠️ Falha ao vincular projeto ao repositório. Faça isso manualmente nas configurações do GitHub Projects.', '⚠️ Fallo al vincular el proyecto al repositorio. Hazlo manualmente en la configuración de GitHub Projects.'),
   link_project_reason: t('Reason: ', 'Motivo: ', 'Motivo: '),
-  link_project_manual: t(
-    'Manual: GitHub → Your Project → Settings → Linked repositories → Add repository',
+  link_project_manual: t('Manual: GitHub → Your Project → Settings → Linked repositories → Add repository',
     'Manual: GitHub → Seu Projeto → Configurações → Repositórios vinculados → Adicionar repositório',
-    'Manual: GitHub → Tu Proyecto → Configuración → Repositorios vinculados → Agregar repositorio'
-  ),
+    'Manual: GitHub → Tu Proyecto → Configuración → Repositorios vinculados → Agregar repositorio'),
   config_columns: t('Configuring Project Columns...', 'Configurando colunas do Projeto...', 'Configurando columnas del Proyecto...'),
   columns_ok: t('✅ Project columns configured successfully.', '✅ Colunas do projeto configuradas com sucesso.', '✅ Columnas del proyecto configuradas con éxito.'),
   columns_warn: t('⚠️ Failed to configure project columns. You may need to add them manually.', '⚠️ Falha ao configurar colunas. Você pode precisar adicioná-las manualmente.', '⚠️ Fallo al configurar columnas. Es posible que debas agregarlas manualmente.'),

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -366,7 +366,7 @@ function linkProjectToRepository(repo, projectId, execFn) {
     const repoNodeId = execFn(
       'gh',
       ['api', `repos/${repo}`, '--jq', '.node_id'],
-      { stdio: ['ignore', 'pipe', 'ignore'] }
+      { stdio: ['ignore', 'pipe', 'pipe'] }
     ).toString().trim();
     execFn(
       'gh',
@@ -380,7 +380,7 @@ function linkProjectToRepository(repo, projectId, execFn) {
     );
     console.log(`  ${i18n.link_project_ok}`);
   } catch (err) {
-    const reason = (err.stderr || '').toString().trim().split('\n')[0];
+    const reason = (err.stderr || err.message || '').toString().trim().split('\n')[0];
     console.log(`  ${yellow}${i18n.link_project_warn}${reset}`);
     if (reason) console.log(`  ${yellow}  ${i18n.link_project_reason}${reason}${reset}`);
     console.log(`  ${yellow}  ${i18n.link_project_manual}${reset}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -671,13 +671,7 @@ async function runFullSetup() {
 
     console.log(`  ${i18n.project_ok}${projectId})`);
 
-    try {
-      const repoNodeId = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.node_id'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-      execFileSync('gh', ['api', 'graphql', '-f', `query=mutation($projectId: ID!, $repositoryId: ID!) { linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) { repository { name } } }`, '-f', `projectId=${projectId}`, '-f', `repositoryId=${repoNodeId}`], { stdio: 'ignore' });
-      console.log(`  ${i18n.link_project_ok}`);
-    } catch (err) {
-      console.log(`  ${i18n.link_project_warn}`);
-    }
+    linkProjectToRepository(repo, projectId);
 
   } catch (err) {
     const isScopeError = (err.message || '').includes("required scopes") || (err.stderr || '').toString().includes("required scopes");
@@ -1141,17 +1135,7 @@ async function runUpgradeToAgentic() {
     projectNumber = pData?.number;
     console.log(`  ${i18n.project_ok}${projectId})`);
 
-    try {
-      const repoNodeId = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.node_id'],
-        { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-      execFileSync('gh', ['api', 'graphql', '-f',
-        'query=mutation($projectId: ID!, $repositoryId: ID!) { linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) { repository { name } } }',
-        '-f', `projectId=${projectId}`, '-f', `repositoryId=${repoNodeId}`],
-        { stdio: 'ignore' });
-      console.log(`  ${i18n.link_project_ok}`);
-    } catch (_) {
-      console.log(`  ${i18n.link_project_warn}`);
-    }
+    linkProjectToRepository(repo, projectId);
   } catch (err) {
     console.log(`  ${i18n.project_err}${err.message}`);
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -121,6 +121,12 @@ const i18n = {
   project_err: t('❌ Failed to create project. Error: ', '❌ Falha ao criar o projeto. Erro: ', '❌ Fallo al crear el proyecto. Error: '),
   link_project_ok: t('✅ Project linked to repository.', '✅ Projeto vinculado ao repositório.', '✅ Proyecto vinculado al repositorio.'),
   link_project_warn: t('⚠️ Failed to link project to repository. Link it manually in GitHub Projects settings.', '⚠️ Falha ao vincular projeto ao repositório. Faça isso manualmente nas configurações do GitHub Projects.', '⚠️ Fallo al vincular el proyecto al repositorio. Hazlo manualmente en la configuración de GitHub Projects.'),
+  link_project_reason: t('Reason: ', 'Motivo: ', 'Motivo: '),
+  link_project_manual: t(
+    'Manual: GitHub → Your Project → Settings → Linked repositories → Add repository',
+    'Manual: GitHub → Seu Projeto → Configurações → Repositórios vinculados → Adicionar repositório',
+    'Manual: GitHub → Tu Proyecto → Configuración → Repositorios vinculados → Agregar repositorio'
+  ),
   config_columns: t('Configuring Project Columns...', 'Configurando colunas do Projeto...', 'Configurando columnas del Proyecto...'),
   columns_ok: t('✅ Project columns configured successfully.', '✅ Colunas do projeto configuradas com sucesso.', '✅ Columnas del proyecto configuradas con éxito.'),
   columns_warn: t('⚠️ Failed to configure project columns. You may need to add them manually.', '⚠️ Falha ao configurar colunas. Você pode precisar adicioná-las manualmente.', '⚠️ Fallo al configurar columnas. Es posible que debas agregarlas manualmente.'),

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -360,6 +360,33 @@ async function setBranchProtection(repo, requiredChecks) {
   }
 }
 
+function linkProjectToRepository(repo, projectId, execFn) {
+  execFn = execFn || execFileSync;
+  try {
+    const repoNodeId = execFn(
+      'gh',
+      ['api', `repos/${repo}`, '--jq', '.node_id'],
+      { stdio: ['ignore', 'pipe', 'ignore'] }
+    ).toString().trim();
+    execFn(
+      'gh',
+      [
+        'api', 'graphql', '-f',
+        'query=mutation($projectId: ID!, $repositoryId: ID!) { linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) { repository { name } } }',
+        '-f', `projectId=${projectId}`,
+        '-f', `repositoryId=${repoNodeId}`
+      ],
+      { stdio: ['ignore', 'ignore', 'pipe'] }
+    );
+    console.log(`  ${i18n.link_project_ok}`);
+  } catch (err) {
+    const reason = (err.stderr || '').toString().trim().split('\n')[0];
+    console.log(`  ${yellow}${i18n.link_project_warn}${reset}`);
+    if (reason) console.log(`  ${yellow}  ${i18n.link_project_reason}${reason}${reset}`);
+    console.log(`  ${yellow}  ${i18n.link_project_manual}${reset}`);
+  }
+}
+
 function copyAdapterFiles(agentChoice, sourceDir, targetDir) {
   const claudeSetupSrc = path.join(sourceDir, 'adapters', 'claude-code', 'skill.md');
   const cursorSetupSrc = path.join(sourceDir, 'adapters', 'cursor',     'rules.md');
@@ -983,7 +1010,7 @@ function resolveMode(args) {
 }
 
 // Export for testing
-if (typeof module !== 'undefined') module.exports = { resolveMode, setActionsVariable, scaffoldLiteTemplates, scaffoldFullTemplates, copyAdapterFiles };
+if (typeof module !== 'undefined') module.exports = { resolveMode, setActionsVariable, scaffoldLiteTemplates, scaffoldFullTemplates, copyAdapterFiles, linkProjectToRepository };
 
 // ─── runLiteSetup ─────────────────────────────────────────────────────────────
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -215,3 +215,51 @@ describe('scaffoldFullTemplates', () => {
     }
   });
 });
+
+describe('linkProjectToRepository', () => {
+  const { linkProjectToRepository } = require('../bin/cli.js');
+
+  it('logs ok message on success', () => {
+    const logs = [];
+    const execFn = () => 'node_id_abc';
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    linkProjectToRepository('owner/repo', 'PVT_123', execFn);
+    console.log = orig;
+    assert.ok(logs.some(l => l.includes('✅')), 'expected ok message');
+  });
+
+  it('logs warning with reason when execFn throws with stderr', () => {
+    const logs = [];
+    const err = new Error('Command failed');
+    err.stderr = Buffer.from('Resource not accessible by personal access token\nmore detail');
+    const execFn = (_cmd, args) => {
+      if (args.includes('graphql')) throw err;
+      return 'node_id_abc';
+    };
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    linkProjectToRepository('owner/repo', 'PVT_123', execFn);
+    console.log = orig;
+    assert.ok(logs.some(l => l.includes('⚠️')), 'expected warning');
+    assert.ok(logs.some(l => l.includes('Resource not accessible')), 'expected first line of stderr');
+    assert.ok(logs.some(l => l.includes('Manual:')), 'expected manual steps');
+  });
+
+  it('logs warning without reason when stderr is empty', () => {
+    const logs = [];
+    const err = new Error('Command failed');
+    err.stderr = Buffer.from('');
+    const execFn = (_cmd, args) => {
+      if (args.includes('graphql')) throw err;
+      return 'node_id_abc';
+    };
+    const orig = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    linkProjectToRepository('owner/repo', 'PVT_123', execFn);
+    console.log = orig;
+    assert.ok(logs.some(l => l.includes('⚠️')), 'expected warning');
+    assert.ok(!logs.some(l => l.includes('Reason:')), 'no reason line when stderr empty');
+    assert.ok(logs.some(l => l.includes('Manual:')), 'expected manual steps');
+  });
+});

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -223,9 +223,12 @@ describe('linkProjectToRepository', () => {
     const logs = [];
     const execFn = () => 'node_id_abc';
     const orig = console.log;
-    console.log = (...a) => logs.push(a.join(' '));
-    linkProjectToRepository('owner/repo', 'PVT_123', execFn);
-    console.log = orig;
+    try {
+      console.log = (...a) => logs.push(a.join(' '));
+      linkProjectToRepository('owner/repo', 'PVT_123', execFn);
+    } finally {
+      console.log = orig;
+    }
     assert.ok(logs.some(l => l.includes('✅')), 'expected ok message');
   });
 
@@ -238,9 +241,12 @@ describe('linkProjectToRepository', () => {
       return 'node_id_abc';
     };
     const orig = console.log;
-    console.log = (...a) => logs.push(a.join(' '));
-    linkProjectToRepository('owner/repo', 'PVT_123', execFn);
-    console.log = orig;
+    try {
+      console.log = (...a) => logs.push(a.join(' '));
+      linkProjectToRepository('owner/repo', 'PVT_123', execFn);
+    } finally {
+      console.log = orig;
+    }
     assert.ok(logs.some(l => l.includes('⚠️')), 'expected warning');
     assert.ok(logs.some(l => l.includes('Resource not accessible')), 'expected first line of stderr');
     assert.ok(logs.some(l => l.includes('Manual:')), 'expected manual steps');
@@ -255,9 +261,12 @@ describe('linkProjectToRepository', () => {
       return 'node_id_abc';
     };
     const orig = console.log;
-    console.log = (...a) => logs.push(a.join(' '));
-    linkProjectToRepository('owner/repo', 'PVT_123', execFn);
-    console.log = orig;
+    try {
+      console.log = (...a) => logs.push(a.join(' '));
+      linkProjectToRepository('owner/repo', 'PVT_123', execFn);
+    } finally {
+      console.log = orig;
+    }
     assert.ok(logs.some(l => l.includes('⚠️')), 'expected warning');
     assert.ok(!logs.some(l => l.includes('Reason:')), 'no reason line when stderr empty');
     assert.ok(logs.some(l => l.includes('Manual:')), 'expected manual steps');


### PR DESCRIPTION
## Summary

- Extracts `linkProjectToRepository(repo, projectId, execFn)` helper (follows existing `setActionsVariable` injectable pattern), replacing two duplicate inline try/catch blocks
- Captures stderr by using `stdio: ['ignore', 'ignore', 'pipe']` instead of `stdio: 'ignore'` on the graphql call
- Shows first line of stderr as reason below the warning, and adds manual linking instructions in EN/PT/ES
- Adds 3 unit tests covering success, failure with stderr, and failure with empty stderr

## Test Plan

- [ ] Run `node --test tests/cli.test.js` — 19 tests, 0 failures
- [ ] Trigger a link failure (e.g. token without `project` scope) — verify reason + manual steps appear

Closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved project-to-repository linking with clearer success confirmation and richer failure messages that extract a concise reason when available, plus step-by-step manual linking guidance.
  * Added localized messaging strings for these user-facing prompts.

* **Tests**
  * Added tests covering success and multiple error/logging scenarios for project linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->