### PR TITLE
fix(#211): delete .agentic-pdlc/templates/ after Setup Mode completes

### DIFF
--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -80,7 +80,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    ```
    rm -f .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md && rm -rf .agentic-pdlc/templates/
    ```
-   **Do NOT run `git add` or any other git command.** These files were never committed and do not exist in the git index. This command must run **before** the commit step.
+   **Do NOT run `git add` or any other git command.** The setup prompt files were never committed and do not exist in the git index. The `templates/` removal must run **before** the commit step so those files are excluded from the `chore: setup` commit.
 9. Commit everything with the message: `chore: setup agentic-pdlc framework`.
 10. Conclude Setup Mode. Read `boardUrl` from `.agentic-pdlc/cli-context.json` and show the user exactly this (do not reconstruct the URL — `boardUrl` already includes the correct `users/` or `orgs/` path segment and `?layout=board`):
 

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -78,7 +78,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    > 5. Reply **"done"** when finished.
 8. **IMPORTANT:** Delete the setup prompt file by running exactly:
    ```
-   rm -f .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md
+   rm -f .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md && rm -rf .agentic-pdlc/templates/
    ```
    **Do NOT run `git add` or any other git command.** These files were never committed and do not exist in the git index. This command must run **before** the commit step.
 9. Commit everything with the message: `chore: setup agentic-pdlc framework`.

--- a/adapters/claude-code/skill.md
+++ b/adapters/claude-code/skill.md
@@ -78,7 +78,7 @@ If any of these files are missing, you are in **Setup Mode**. Do not proceed wit
    > 5. Reply **"done"** when finished.
 8. **IMPORTANT:** Delete the setup prompt file by running exactly:
    ```
-   rm -f .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md && rm -rf .agentic-pdlc/templates/
+   rm -rf .agentic-setup.md .agentic-setup-prompt.md .agentic-pdlc/SETUP_PROMPT.md .agentic-pdlc/templates/
    ```
    **Do NOT run `git add` or any other git command.** The setup prompt files were never committed and do not exist in the git index. The `templates/` removal must run **before** the commit step so those files are excluded from the `chore: setup` commit.
 9. Commit everything with the message: `chore: setup agentic-pdlc framework`.


### PR DESCRIPTION
## Summary

- After Setup Mode deploys all files and steps through the interactive questions, `.agentic-pdlc/templates/` (21 files) was committed to the user's repo forever with no post-setup purpose
- Added `&& rm -rf .agentic-pdlc/templates/` to the cleanup command in step 8 of `adapters/claude-code/skill.md`, before the `chore: setup` commit
- Also fixed the adjacent comment which falsely claimed "these files were never committed" — the templates directory is committed, so the comment now distinguishes between the two cases

## Test plan

- [ ] All 11 existing tests pass (verified)
- [ ] `rm -rf` on non-existent dir exits 0 — safe for lite profile where `templates/` may be absent
- [ ] `.agentic-pdlc/hooks/` and `.agentic-pdlc/cli-context.json` are not touched by this command

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Setup Mode cleanup instructions to also remove the templates directory during initialization, ensuring setup artifacts are fully cleared and preventing leftover template files. Clarified the cleanup command so users can reliably remove all related setup files and directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->